### PR TITLE
Add parallel variants of LeMAC for VAES-enabled CPUs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS= -Wall -Wextra -O3 -g -march=native
+CFLAGS= -Wall -Wextra -O3 -g -march=native -fno-lto
 
 all: lemac.so petitmac.so
 

--- a/benchmark/Jean-Nikolic/bench.c
+++ b/benchmark/Jean-Nikolic/bench.c
@@ -100,7 +100,10 @@ int main() {
   int cycles[1000];
   uint8_t Z = 0;
   for (int i=0; i<1000; i++) {
-    getrandom(N, sizeof(N), 0);
+    if (getrandom(N, sizeof(N), 0) != sizeof(N)) {
+      fprintf(stderr, "getrandom failed\n");
+      exit(1);
+    }
 #ifdef PERF_EV
     ioctl(fd, PERF_EVENT_IOC_RESET, 0);
     ioctl(fd, PERF_EVENT_IOC_ENABLE, 0);

--- a/benchmark/LeMac-X2/Makefile
+++ b/benchmark/LeMac-X2/Makefile
@@ -1,0 +1,3 @@
+CFLAGS= -Wall -Wextra -O3 -fno-lto -mavx2 -mvaes -maes
+
+bench:

--- a/benchmark/LeMac-X2/Makefile
+++ b/benchmark/LeMac-X2/Makefile
@@ -1,3 +1,11 @@
 CFLAGS= -Wall -Wextra -O3 -fno-lto -mavx2 -mvaes -maes
 
-bench:
+all: bench
+
+bench: bench.c
+	$(CC) $(CFLAGS) -o $@ $^
+
+clean:
+	rm -f bench *.o
+
+.PHONY: all clean

--- a/benchmark/LeMac-X2/bench.c
+++ b/benchmark/LeMac-X2/bench.c
@@ -102,7 +102,10 @@ int main() {
   int cycles[1000];
   uint8_t Z = 0;
   for (int i=0; i<1000; i++) {
-    getrandom(N, sizeof(N), 0);
+    if (getrandom(N, sizeof(N), 0) != sizeof(N)) {
+      fprintf(stderr, "getrandom failed\n");
+      exit(1);
+    }
 #ifdef PERF_EV
     ioctl(fd, PERF_EVENT_IOC_RESET, 0);
     ioctl(fd, PERF_EVENT_IOC_ENABLE, 0);

--- a/benchmark/LeMac-X2/bench.c
+++ b/benchmark/LeMac-X2/bench.c
@@ -1,0 +1,139 @@
+#include <stdint.h>
+#include <stdio.h>
+
+#include "lemac-x2.c"
+
+// Getrandom
+# if __GLIBC__ > 2 || __GLIBC_MINOR__ > 24
+
+#include <sys/random.h>
+
+#else /* older glibc */
+
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <errno.h>
+
+int getrandom(void *buf, size_t buflen, unsigned int flags) {
+    return syscall(SYS_getrandom, buf, buflen, flags);
+}
+# endif
+
+#ifndef MSIZE
+#define MSIZE 1*1024
+#endif
+
+void setrandom(void* buf, size_t buflen) {
+  size_t l = getrandom(buf, buflen, 0);
+  if (l != buflen) {
+    fprintf(stderr, "Error initializing random state\n");
+    exit(EXIT_FAILURE);
+  }
+}
+
+// Uncomment to use perf_event_open for benchmarks
+// #define PERF_EV
+
+
+// Uncomment to use rdpmc for benchmarks -- this requires running with perf stat -e cycles:u
+// #define USE_RDPMC
+
+
+#ifdef PERF_EV
+// Sample code from perf_event_open manpage
+
+#include <linux/perf_event.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+static long
+perf_event_open(struct perf_event_attr *hw_event, pid_t pid,
+                int cpu, int group_fd, unsigned long flags)
+{
+  int ret;
+  
+  ret = syscall(SYS_perf_event_open, hw_event, pid, cpu,
+                group_fd, flags);
+  return ret;
+}
+#endif
+
+int main() {
+  uint8_t *M  = aligned_alloc(32, MSIZE);   
+  uint8_t  N[16];
+  uint8_t  K[16];
+  uint8_t  T[16];
+
+  memset(M, 0, MSIZE);
+
+#ifdef PERF_EV
+  int                     fd;
+  long long               count;
+  struct perf_event_attr  pe;
+  
+  memset(&pe, 0, sizeof(pe));
+  pe.type = PERF_TYPE_HARDWARE;
+  pe.size = sizeof(pe);
+  pe.config = PERF_COUNT_HW_CPU_CYCLES;
+  pe.disabled = 1;
+  pe.exclude_kernel = 1;
+  pe.exclude_hv = 1;
+  
+  fd = perf_event_open(&pe, 0, -1, -1, 0);
+  if (fd == -1) {
+    fprintf(stderr, "Error opening leader %llx\n", pe.config);
+    exit(EXIT_FAILURE);
+  }
+#endif
+
+  setrandom(M, MSIZE);
+  setrandom(N, sizeof(N));
+  setrandom(K, sizeof(K));
+  
+  context ctx;
+  lemac_x2_init(&ctx, K);
+
+  // Blank computation
+  lemac_x2_MAC(&ctx, N, M, MSIZE, T);
+
+  // Benchmarks
+  int cycles[1000];
+  uint8_t Z = 0;
+  for (int i=0; i<1000; i++) {
+    getrandom(N, sizeof(N), 0);
+#ifdef PERF_EV
+    ioctl(fd, PERF_EVENT_IOC_RESET, 0);
+    ioctl(fd, PERF_EVENT_IOC_ENABLE, 0);
+#else
+#ifdef USE_RDPMC
+    unsigned long long start = __builtin_ia32_rdpmc(0);
+    _mm_lfence();
+#else
+    uint32_t tmp;
+    unsigned long long start = __builtin_ia32_rdtscp (&tmp);
+#endif
+#endif
+    lemac_x2_MAC(&ctx, N, M, MSIZE, T);
+    Z ^= T[0];
+#ifdef PERF_EV
+    ioctl(fd, PERF_EVENT_IOC_DISABLE, 0);
+    read(fd, &count, sizeof(count));
+    cycles[i] = count;
+#else
+#ifdef USE_RDPMC
+    _mm_lfence();
+    unsigned long long stop = __builtin_ia32_rdpmc(0);
+#else
+    unsigned long long stop = __builtin_ia32_rdtscp (&tmp);
+#endif
+    cycles[i] = stop-start;
+#endif
+  }
+
+  for (int i=0; i<1000; i++) {
+    printf ("%5.3f\n", 1.0*cycles[i]/(MSIZE));
+  }
+  return Z; // Just force GCC to keep the computation
+}

--- a/benchmark/LeMac-X2/lemac-x2.c
+++ b/benchmark/LeMac-X2/lemac-x2.c
@@ -1,0 +1,227 @@
+/* LeMac-X2 AES-NI implementation
+ *
+ * This file implements a parallel variant of LeMAC for measuring
+ * the performance impact of leveraging VAES instructions.
+ */
+
+#include <stdint.h>
+#include <immintrin.h>
+#include <string.h>
+
+#define STATE_0 _mm256_set_epi64x(0,0,0,0)
+
+#define tabsize(T) (sizeof(T)/sizeof((T)[0]))
+
+typedef struct {
+  __m256i S[9];
+} state;
+
+typedef  struct {
+  state init;
+  __m256i keys[2][11];
+  __m256i subkeys[18];
+} context;
+
+
+// AES key schedule from https://www.intel.com/content/dam/doc/white-paper/advanced-encryption-standard-new-instructions-set-paper.pdf
+
+inline __m128i AES_128_ASSIST (__m128i temp1, __m128i temp2)     {
+  __m128i temp3;
+  temp2 = _mm_shuffle_epi32 (temp2 ,0xff);
+  temp3 = _mm_slli_si128 (temp1, 0x4);
+  temp1 = _mm_xor_si128 (temp1, temp3);
+  temp3 = _mm_slli_si128 (temp3, 0x4);
+  temp1 = _mm_xor_si128 (temp1, temp3);
+  temp3 = _mm_slli_si128 (temp3, 0x4);
+  temp1 = _mm_xor_si128 (temp1, temp3);
+  temp1 = _mm_xor_si128 (temp1, temp2);
+  return temp1;
+}
+
+void AES_KS (__m128i K, __m256i *Key_Schedule)     {
+  __m128i temp1, temp2;
+  temp1 = K;
+  Key_Schedule[0] = _mm256_broadcastsi128_si256(temp1);
+  temp2 = _mm_aeskeygenassist_si128 (temp1 ,0x1);
+  temp1 = AES_128_ASSIST(temp1, temp2);
+  Key_Schedule[1] = _mm256_broadcastsi128_si256(temp1);
+  temp2 = _mm_aeskeygenassist_si128 (temp1,0x2);
+  temp1 = AES_128_ASSIST(temp1, temp2);
+  Key_Schedule[2] = _mm256_broadcastsi128_si256(temp1);
+  temp2 = _mm_aeskeygenassist_si128 (temp1,0x4);
+  temp1 = AES_128_ASSIST(temp1, temp2);
+  Key_Schedule[3] = _mm256_broadcastsi128_si256(temp1);
+  temp2 = _mm_aeskeygenassist_si128 (temp1,0x8);
+  temp1 = AES_128_ASSIST(temp1, temp2);
+  Key_Schedule[4] = _mm256_broadcastsi128_si256(temp1);
+  temp2 = _mm_aeskeygenassist_si128 (temp1,0x10);
+  temp1 = AES_128_ASSIST(temp1, temp2);
+  Key_Schedule[5] = _mm256_broadcastsi128_si256(temp1);
+  temp2 = _mm_aeskeygenassist_si128 (temp1,0x20);
+  temp1 = AES_128_ASSIST(temp1, temp2);
+  Key_Schedule[6] = _mm256_broadcastsi128_si256(temp1);
+  temp2 = _mm_aeskeygenassist_si128 (temp1,0x40);
+  temp1 = AES_128_ASSIST(temp1, temp2);
+  Key_Schedule[7] = _mm256_broadcastsi128_si256(temp1);
+  temp2 = _mm_aeskeygenassist_si128 (temp1,0x80);
+  temp1 = AES_128_ASSIST(temp1, temp2);
+  Key_Schedule[8] = _mm256_broadcastsi128_si256(temp1);
+  temp2 = _mm_aeskeygenassist_si128 (temp1,0x1b);
+  temp1 = AES_128_ASSIST(temp1, temp2);
+  Key_Schedule[9] = _mm256_broadcastsi128_si256(temp1);
+  temp2 = _mm_aeskeygenassist_si128 (temp1,0x36);
+  temp1 = AES_128_ASSIST(temp1, temp2);
+  Key_Schedule[10] = _mm256_broadcastsi128_si256(temp1);
+}
+
+__m256i AES(const __m256i *Ki, __m256i x) {
+  x ^= Ki[0];
+  x = _mm256_aesenc_epi128(x, Ki[1]);
+  x = _mm256_aesenc_epi128(x, Ki[2]);
+  x = _mm256_aesenc_epi128(x, Ki[3]);
+  x = _mm256_aesenc_epi128(x, Ki[4]);
+  x = _mm256_aesenc_epi128(x, Ki[5]);
+  x = _mm256_aesenc_epi128(x, Ki[6]);
+  x = _mm256_aesenc_epi128(x, Ki[7]);
+  x = _mm256_aesenc_epi128(x, Ki[8]);
+  x = _mm256_aesenc_epi128(x, Ki[9]);
+  x = _mm256_aesenclast_epi128(x, Ki[10]);
+  return x;
+}
+
+__m256i AES_modified(const __m256i *Ki, __m256i x) {
+  x ^= Ki[0];
+  x = _mm256_aesenc_epi128(x, Ki[1]);
+  x = _mm256_aesenc_epi128(x, Ki[2]);
+  x = _mm256_aesenc_epi128(x, Ki[3]);
+  x = _mm256_aesenc_epi128(x, Ki[4]);
+  x = _mm256_aesenc_epi128(x, Ki[5]);
+  x = _mm256_aesenc_epi128(x, Ki[6]);
+  x = _mm256_aesenc_epi128(x, Ki[7]);
+  x = _mm256_aesenc_epi128(x, Ki[8]);
+  x = _mm256_aesenc_epi128(x, Ki[9]);
+  x = _mm256_aesenc_epi128(x, _mm256_set_epi64x(0,0,0,0));
+  return x;
+}
+
+void lemac_x2_init(context *ctx, const uint8_t k[]) {
+  const __m128i *K = (__m128i*)k;
+
+  // Mask is <number of lanes - 1> || <lane id> || 0*
+  const uint64_t mask0 = (0x01ULL << 56) | (0x00ULL << 48);
+  const uint64_t mask1 = (0x01ULL << 56) | (0x01ULL << 48);
+  __m256i Ki[11];
+  AES_KS(*K, Ki);
+
+  // Kinit 0 --> 8
+  for (unsigned i=0; i<tabsize(ctx->init.S); i++)
+    ctx->init.S[i] = AES(Ki, _mm256_set_epi64x(mask0,i,mask1,i));
+
+  // Kinit 9 --> 26
+  for (unsigned i=0; i<tabsize(ctx->subkeys); i++)
+    ctx->subkeys[i] = AES(Ki, _mm256_set_epi64x(mask0,i+tabsize(ctx->init.S),
+                                                mask1,i+tabsize(ctx->init.S)));
+
+  // k2 27
+  AES_KS(_mm256_castsi256_si128(AES(Ki, _mm256_set_epi64x(mask0,tabsize(ctx->init.S)+tabsize(ctx->subkeys),
+                                                          mask1,tabsize(ctx->init.S)+tabsize(ctx->subkeys)))), ctx->keys[0]);
+
+  // k3 28
+  AES_KS(_mm256_castsi256_si128(AES(Ki, _mm256_set_epi64x(mask0,tabsize(ctx->init.S)+tabsize(ctx->subkeys)+1,
+                                                          mask1,tabsize(ctx->init.S)+tabsize(ctx->subkeys)+1))), ctx->keys[1]);
+}
+
+
+#define ROUND(S, M0, M1, M2, M3, RR, R0, R1, R2) do {   \
+    __m256i T = S.S[8];                                                     \
+    S.S[8] = _mm256_aesenc_epi128(S.S[7],M3);                   \
+    S.S[7] = _mm256_aesenc_epi128(S.S[6],M1);                   \
+    S.S[6] = _mm256_aesenc_epi128(S.S[5],M1);                   \
+    S.S[5] = _mm256_aesenc_epi128(S.S[4],M0);                   \
+    S.S[4] = _mm256_aesenc_epi128(S.S[3],M0);                   \
+    S.S[3] = _mm256_aesenc_epi128(S.S[2],R1 ^ R2);              \
+    S.S[2] = _mm256_aesenc_epi128(S.S[1],M3);                   \
+    S.S[1] = _mm256_aesenc_epi128(S.S[0],M3);                   \
+    S.S[0] = S.S[0] ^ T ^ M2;                                           \
+    R2 = R1;                                                    \
+    R1 = R0;                                                    \
+    R0 = RR ^ M1;                                               \
+    RR = M2;                                                    \
+  } while (0);
+
+state lemac_x2_AU(context *ctx, const uint8_t *m, size_t mlen, const __m256i N) {
+  /* state S = ctx->init; */
+  // Padding
+  size_t m_padded_len = mlen - (mlen % 128) + 128;
+  uint8_t m_padding[128];
+  memcpy(m_padding, m + (mlen / 128) * 128, mlen % 128);
+  m_padding[mlen % 128] = 1;
+  __m256i *M_padding = (__m256i*) m_padding;
+  for (size_t i = 1 + (mlen % 128); i < 128; ++i){
+    m_padding[i] = 0;
+  }
+
+  const __m256i *M = (__m256i*)m;
+  __m256i *Mfin = (__m256i*)(m + m_padded_len - 128);
+
+  state S = ctx->init;
+
+  __m256i RR = STATE_0;
+  __m256i R0 = STATE_0;
+  __m256i R1 = STATE_0;
+  __m256i R2 = STATE_0;
+  // Main rounds
+  for (;M < Mfin; M+=4) {
+    ROUND(S, M[0], M[1], M[2], M[3], RR, R0, R1, R2);
+  }
+
+  // Last round (padding)
+  ROUND(S, M_padding[0], M_padding[1], M_padding[2], M_padding[3], RR, R0, R1, R2);
+
+  // Four final rounds to absorb message state
+  ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
+  ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
+  ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
+  ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
+
+  // Absorb the tag from all the lanes into lane 0
+  // Lane1 is then not used any more, but keep using 256-bit vectors for simplicity
+  __m256i T = N ^ AES(ctx->keys[0], N);
+  T ^= AES_modified(ctx->subkeys  , S.S[0]);
+  T ^= AES_modified(ctx->subkeys+1, S.S[1]);
+  T ^= AES_modified(ctx->subkeys+2, S.S[2]);
+  T ^= AES_modified(ctx->subkeys+3, S.S[3]);
+  T ^= AES_modified(ctx->subkeys+4, S.S[4]);
+  T ^= AES_modified(ctx->subkeys+5, S.S[5]);
+  T ^= AES_modified(ctx->subkeys+6, S.S[6]);
+  T ^= AES_modified(ctx->subkeys+7, S.S[7]);
+  T ^= AES_modified(ctx->subkeys+8, S.S[8]);
+
+  const __m256i T0 = _mm256_broadcastsi128_si256(_mm256_extracti128_si256(T, 0));
+  const __m256i T1 = _mm256_broadcastsi128_si256(_mm256_extracti128_si256(T, 1));
+  ROUND(S, T0, T1, STATE_0, STATE_0, RR, R0, R1, R2);
+  ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
+  ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
+  ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
+  ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
+
+  return S;
+}
+
+void lemac_x2_MAC(context *ctx, const uint8_t *nonce, const uint8_t *m, size_t mlen, uint8_t *tag) {
+  const __m256i N = _mm256_broadcastsi128_si256(*(const __m128i *) nonce);
+  state S = lemac_x2_AU(ctx, m, mlen, N);
+
+  __m256i T = N ^ AES(ctx->keys[0], N);
+  T ^= AES_modified(ctx->subkeys  , S.S[0]);
+  T ^= AES_modified(ctx->subkeys+1, S.S[1]);
+  T ^= AES_modified(ctx->subkeys+2, S.S[2]);
+  T ^= AES_modified(ctx->subkeys+3, S.S[3]);
+  T ^= AES_modified(ctx->subkeys+4, S.S[4]);
+  T ^= AES_modified(ctx->subkeys+5, S.S[5]);
+  T ^= AES_modified(ctx->subkeys+6, S.S[6]);
+  T ^= AES_modified(ctx->subkeys+7, S.S[7]);
+  T ^= AES_modified(ctx->subkeys+8, S.S[8]);
+
+  *(__m128i*)tag = _mm256_castsi256_si128(AES(ctx->keys[1], T));
+}

--- a/benchmark/LeMac-X2/lemac-x2.c
+++ b/benchmark/LeMac-X2/lemac-x2.c
@@ -149,7 +149,7 @@ void lemac_x2_init(context *ctx, const uint8_t k[]) {
     RR = M2;                                                    \
   } while (0);
 
-state lemac_x2_AU(context *ctx, const uint8_t *m, size_t mlen, const __m256i N) {
+state lemac_x2_AU(context *ctx, const uint8_t *m, size_t mlen) {
   /* state S = ctx->init; */
   // Padding
   size_t m_padded_len = mlen - (mlen % 128) + 128;
@@ -184,33 +184,12 @@ state lemac_x2_AU(context *ctx, const uint8_t *m, size_t mlen, const __m256i N) 
   ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
   ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
 
-  // Absorb the tag from all the lanes into lane 0
-  // Lane1 is then not used any more, but keep using 256-bit vectors for simplicity
-  __m256i T = N ^ AES(ctx->keys[0], N);
-  T ^= AES_modified(ctx->subkeys  , S.S[0]);
-  T ^= AES_modified(ctx->subkeys+1, S.S[1]);
-  T ^= AES_modified(ctx->subkeys+2, S.S[2]);
-  T ^= AES_modified(ctx->subkeys+3, S.S[3]);
-  T ^= AES_modified(ctx->subkeys+4, S.S[4]);
-  T ^= AES_modified(ctx->subkeys+5, S.S[5]);
-  T ^= AES_modified(ctx->subkeys+6, S.S[6]);
-  T ^= AES_modified(ctx->subkeys+7, S.S[7]);
-  T ^= AES_modified(ctx->subkeys+8, S.S[8]);
-
-  const __m256i T0 = _mm256_broadcastsi128_si256(_mm256_extracti128_si256(T, 0));
-  const __m256i T1 = _mm256_broadcastsi128_si256(_mm256_extracti128_si256(T, 1));
-  ROUND(S, T0, T1, STATE_0, STATE_0, RR, R0, R1, R2);
-  ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
-  ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
-  ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
-  ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
-
   return S;
 }
 
 void lemac_x2_MAC(context *ctx, const uint8_t *nonce, const uint8_t *m, size_t mlen, uint8_t *tag) {
   const __m256i N = _mm256_broadcastsi128_si256(*(const __m128i *) nonce);
-  state S = lemac_x2_AU(ctx, m, mlen, N);
+  state S = lemac_x2_AU(ctx, m, mlen);
 
   __m256i T = N ^ AES(ctx->keys[0], N);
   T ^= AES_modified(ctx->subkeys  , S.S[0]);
@@ -222,6 +201,9 @@ void lemac_x2_MAC(context *ctx, const uint8_t *nonce, const uint8_t *m, size_t m
   T ^= AES_modified(ctx->subkeys+6, S.S[6]);
   T ^= AES_modified(ctx->subkeys+7, S.S[7]);
   T ^= AES_modified(ctx->subkeys+8, S.S[8]);
+
+  T = _mm256_broadcastsi128_si256(_mm_xor_si128(_mm256_extracti128_si256(T, 0),
+                                                _mm256_extracti128_si256(T, 1)));
 
   *(__m128i*)tag = _mm256_castsi256_si128(AES(ctx->keys[1], T));
 }

--- a/benchmark/LeMac-X2/lemac-x2.c
+++ b/benchmark/LeMac-X2/lemac-x2.c
@@ -188,11 +188,10 @@ state lemac_x2_AU(context *ctx, const uint8_t *m, size_t mlen) {
 }
 
 void lemac_x2_MAC(context *ctx, const uint8_t *nonce, const uint8_t *m, size_t mlen, uint8_t *tag) {
-  const __m256i N = _mm256_broadcastsi128_si256(*(const __m128i *) nonce);
   state S = lemac_x2_AU(ctx, m, mlen);
 
-  __m256i T = N ^ AES(ctx->keys[0], N);
-  T ^= AES_modified(ctx->subkeys  , S.S[0]);
+  __m256i T;
+  T  = AES_modified(ctx->subkeys  , S.S[0]);
   T ^= AES_modified(ctx->subkeys+1, S.S[1]);
   T ^= AES_modified(ctx->subkeys+2, S.S[2]);
   T ^= AES_modified(ctx->subkeys+3, S.S[3]);
@@ -202,8 +201,13 @@ void lemac_x2_MAC(context *ctx, const uint8_t *nonce, const uint8_t *m, size_t m
   T ^= AES_modified(ctx->subkeys+7, S.S[7]);
   T ^= AES_modified(ctx->subkeys+8, S.S[8]);
 
-  T = _mm256_broadcastsi128_si256(_mm_xor_si128(_mm256_extracti128_si256(T, 0),
-                                                _mm256_extracti128_si256(T, 1)));
+  __m128i T_128 = _mm_xor_si128(_mm256_extracti128_si256(T, 0),
+                                _mm256_extracti128_si256(T, 1));
 
-  *(__m128i*)tag = _mm256_castsi256_si128(AES(ctx->keys[1], T));
+  const __m128i N = *(const __m128i *) nonce;
+  __m256i N_256 = _mm256_broadcastsi128_si256(N);
+  __m128i nonce_contrib = _mm256_castsi256_si128(AES(ctx->keys[0], N_256));
+  T_128 ^= N ^ nonce_contrib;
+
+  *(__m128i*)tag = _mm256_castsi256_si128(AES(ctx->keys[1], _mm256_broadcastsi128_si256(T_128)));
 }

--- a/benchmark/LeMac-X4/Makefile
+++ b/benchmark/LeMac-X4/Makefile
@@ -1,3 +1,11 @@
 CFLAGS= -Wall -Wextra -O3 -fno-lto -mavx512f -mavx512vl -mvaes -maes
 
-bench:
+all: bench
+
+bench: bench.c
+	$(CC) $(CFLAGS) -o $@ $^
+
+clean:
+	rm -f bench *.o
+
+.PHONY: all clean

--- a/benchmark/LeMac-X4/Makefile
+++ b/benchmark/LeMac-X4/Makefile
@@ -1,0 +1,3 @@
+CFLAGS= -Wall -Wextra -O3 -fno-lto -mavx512f -mavx512vl -mvaes -maes
+
+bench:

--- a/benchmark/LeMac-X4/bench.c
+++ b/benchmark/LeMac-X4/bench.c
@@ -1,0 +1,139 @@
+#include <stdint.h>
+#include <stdio.h>
+
+#include "lemac-x4.c"
+
+// Getrandom
+# if __GLIBC__ > 2 || __GLIBC_MINOR__ > 24
+
+#include <sys/random.h>
+
+#else /* older glibc */
+
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <errno.h>
+
+int getrandom(void *buf, size_t buflen, unsigned int flags) {
+    return syscall(SYS_getrandom, buf, buflen, flags);
+}
+# endif
+
+#ifndef MSIZE
+#define MSIZE 1*1024
+#endif
+
+void setrandom(void* buf, size_t buflen) {
+  size_t l = getrandom(buf, buflen, 0);
+  if (l != buflen) {
+    fprintf(stderr, "Error initializing random state\n");
+    exit(EXIT_FAILURE);
+  }
+}
+
+// Uncomment to use perf_event_open for benchmarks
+// #define PERF_EV
+
+
+// Uncomment to use rdpmc for benchmarks -- this requires running with perf stat -e cycles:u
+// #define USE_RDPMC
+
+
+#ifdef PERF_EV
+// Sample code from perf_event_open manpage
+
+#include <linux/perf_event.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+static long
+perf_event_open(struct perf_event_attr *hw_event, pid_t pid,
+                int cpu, int group_fd, unsigned long flags)
+{
+  int ret;
+  
+  ret = syscall(SYS_perf_event_open, hw_event, pid, cpu,
+                group_fd, flags);
+  return ret;
+}
+#endif
+
+int main() {
+  uint8_t *M  = aligned_alloc(64, MSIZE);
+  uint8_t  N[16];
+  uint8_t  K[16];
+  uint8_t  T[16];
+
+  memset(M, 0, MSIZE);
+   
+#ifdef PERF_EV
+  int                     fd;
+  long long               count;
+  struct perf_event_attr  pe;
+  
+  memset(&pe, 0, sizeof(pe));
+  pe.type = PERF_TYPE_HARDWARE;
+  pe.size = sizeof(pe);
+  pe.config = PERF_COUNT_HW_CPU_CYCLES;
+  pe.disabled = 1;
+  pe.exclude_kernel = 1;
+  pe.exclude_hv = 1;
+  
+  fd = perf_event_open(&pe, 0, -1, -1, 0);
+  if (fd == -1) {
+    fprintf(stderr, "Error opening leader %llx\n", pe.config);
+    exit(EXIT_FAILURE);
+  }
+#endif
+
+  setrandom(M, MSIZE);
+  setrandom(N, sizeof(N));
+  setrandom(K, sizeof(K));
+  
+  context ctx;
+  lemac_x4_init(&ctx, K);
+
+  // Blank computation
+  lemac_x4_MAC(&ctx, N, M, MSIZE, T);
+
+  // Benchmarks
+  int cycles[1000];
+  uint8_t Z = 0;
+  for (int i=0; i<1000; i++) {
+    getrandom(N, sizeof(N), 0);
+#ifdef PERF_EV
+    ioctl(fd, PERF_EVENT_IOC_RESET, 0);
+    ioctl(fd, PERF_EVENT_IOC_ENABLE, 0);
+#else
+#ifdef USE_RDPMC
+    unsigned long long start = __builtin_ia32_rdpmc(0);
+    _mm_lfence();
+#else
+    uint32_t tmp;
+    unsigned long long start = __builtin_ia32_rdtscp (&tmp);
+#endif
+#endif
+    lemac_x4_MAC(&ctx, N, M, MSIZE, T);
+    Z ^= T[0];
+#ifdef PERF_EV
+    ioctl(fd, PERF_EVENT_IOC_DISABLE, 0);
+    read(fd, &count, sizeof(count));
+    cycles[i] = count;
+#else
+#ifdef USE_RDPMC
+    _mm_lfence();
+    unsigned long long stop = __builtin_ia32_rdpmc(0);
+#else
+    unsigned long long stop = __builtin_ia32_rdtscp (&tmp);
+#endif
+    cycles[i] = stop-start;
+#endif
+  }
+
+  for (int i=0; i<1000; i++) {
+    printf ("%5.3f\n", 1.0*cycles[i]/(MSIZE));
+  }
+  return Z; // Just force GCC to keep the computation
+}

--- a/benchmark/LeMac-X4/bench.c
+++ b/benchmark/LeMac-X4/bench.c
@@ -102,7 +102,10 @@ int main() {
   int cycles[1000];
   uint8_t Z = 0;
   for (int i=0; i<1000; i++) {
-    getrandom(N, sizeof(N), 0);
+    if (getrandom(N, sizeof(N), 0) != sizeof(N)) {
+      fprintf(stderr, "getrandom failed\n");
+      exit(1);
+    }
 #ifdef PERF_EV
     ioctl(fd, PERF_EVENT_IOC_RESET, 0);
     ioctl(fd, PERF_EVENT_IOC_ENABLE, 0);

--- a/benchmark/LeMac-X4/lemac-x4.c
+++ b/benchmark/LeMac-X4/lemac-x4.c
@@ -157,7 +157,7 @@ void lemac_x4_init(context *ctx, const uint8_t k[]) {
     RR = M2;                                                    \
   } while (0);
 
-state lemac_x4_AU(context *ctx, const uint8_t *m, size_t mlen, const __m512i N) {
+state lemac_x4_AU(context *ctx, const uint8_t *m, size_t mlen) {
   /* state S = ctx->init; */
   // Padding
   size_t m_padded_len = mlen - (mlen % 256) + 256;
@@ -192,35 +192,12 @@ state lemac_x4_AU(context *ctx, const uint8_t *m, size_t mlen, const __m512i N) 
   ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
   ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
 
-  // Absorb the tag from all the lanes into lane 0
-  // Lanes > 0 are then not used any more, but keep using 512-bit vectors for simplicity
-  __m512i T = N ^ AES(ctx->keys[0], N);
-  T ^= AES_modified(ctx->subkeys  , S.S[0]);
-  T ^= AES_modified(ctx->subkeys+1, S.S[1]);
-  T ^= AES_modified(ctx->subkeys+2, S.S[2]);
-  T ^= AES_modified(ctx->subkeys+3, S.S[3]);
-  T ^= AES_modified(ctx->subkeys+4, S.S[4]);
-  T ^= AES_modified(ctx->subkeys+5, S.S[5]);
-  T ^= AES_modified(ctx->subkeys+6, S.S[6]);
-  T ^= AES_modified(ctx->subkeys+7, S.S[7]);
-  T ^= AES_modified(ctx->subkeys+8, S.S[8]);
-
-  const __m512i T0 = _mm512_broadcast_i32x4(_mm512_extracti32x4_epi32(T, 0));
-  const __m512i T1 = _mm512_broadcast_i32x4(_mm512_extracti32x4_epi32(T, 1));
-  const __m512i T2 = _mm512_broadcast_i32x4(_mm512_extracti32x4_epi32(T, 2));
-  const __m512i T3 = _mm512_broadcast_i32x4(_mm512_extracti32x4_epi32(T, 3));
-  ROUND(S, T0, T1, T2, T3, RR, R0, R1, R2);
-  ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
-  ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
-  ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
-  ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
-
   return S;
 }
 
 void lemac_x4_MAC(context *ctx, const uint8_t *nonce, const uint8_t *m, size_t mlen, uint8_t *tag) {
   const __m512i N = _mm512_broadcast_i32x4(*(const __m128i *) nonce);
-  state S = lemac_x4_AU(ctx, m, mlen, N);
+  state S = lemac_x4_AU(ctx, m, mlen);
 
   __m512i T = N ^ AES(ctx->keys[0], N);
   T ^= AES_modified(ctx->subkeys  , S.S[0]);
@@ -232,6 +209,9 @@ void lemac_x4_MAC(context *ctx, const uint8_t *nonce, const uint8_t *m, size_t m
   T ^= AES_modified(ctx->subkeys+6, S.S[6]);
   T ^= AES_modified(ctx->subkeys+7, S.S[7]);
   T ^= AES_modified(ctx->subkeys+8, S.S[8]);
+  T = _mm512_broadcast_i32x4(_mm_xor_si128(_mm_xor_si128(_mm_xor_si128
+                              (_mm512_extracti32x4_epi32(T, 0),  _mm512_extracti32x4_epi32(T, 1)),
+                               _mm512_extracti32x4_epi32(T, 2)), _mm512_extracti32x4_epi32(T, 3)));
 
   *(__m128i*)tag = _mm512_castsi512_si128(AES(ctx->keys[1], T));
 }

--- a/benchmark/LeMac-X4/lemac-x4.c
+++ b/benchmark/LeMac-X4/lemac-x4.c
@@ -1,0 +1,237 @@
+/* LeMac-X4 AES-NI implementation
+ *
+ * This file implements a parallel variant of LeMAC for measuring
+ * the performance impact of leveraging VAES instructions.
+ */
+
+#include <stdint.h>
+#include <immintrin.h>
+#include <string.h>
+
+#define STATE_0 _mm512_set_epi64(0,0,0,0,0,0,0,0)
+
+#define tabsize(T) (sizeof(T)/sizeof((T)[0]))
+
+typedef struct {
+  __m512i S[9];
+} state;
+
+typedef  struct {
+  state init;
+  __m512i keys[2][11];
+  __m512i subkeys[18];
+} context;
+
+
+// AES key schedule from https://www.intel.com/content/dam/doc/white-paper/advanced-encryption-standard-new-instructions-set-paper.pdf
+
+inline __m128i AES_128_ASSIST (__m128i temp1, __m128i temp2)     {
+  __m128i temp3;
+  temp2 = _mm_shuffle_epi32 (temp2 ,0xff);
+  temp3 = _mm_slli_si128 (temp1, 0x4);
+  temp1 = _mm_xor_si128 (temp1, temp3);
+  temp3 = _mm_slli_si128 (temp3, 0x4);
+  temp1 = _mm_xor_si128 (temp1, temp3);
+  temp3 = _mm_slli_si128 (temp3, 0x4);
+  temp1 = _mm_xor_si128 (temp1, temp3);
+  temp1 = _mm_xor_si128 (temp1, temp2);
+  return temp1;
+}
+
+void AES_KS (__m128i K, __m512i *Key_Schedule)     {
+  __m128i temp1, temp2;
+  temp1 = K;
+  Key_Schedule[0] = _mm512_broadcast_i32x4(temp1);
+  temp2 = _mm_aeskeygenassist_si128 (temp1 ,0x1);
+  temp1 = AES_128_ASSIST(temp1, temp2);
+  Key_Schedule[1] = _mm512_broadcast_i32x4(temp1);
+  temp2 = _mm_aeskeygenassist_si128 (temp1,0x2);
+  temp1 = AES_128_ASSIST(temp1, temp2);
+  Key_Schedule[2] = _mm512_broadcast_i32x4(temp1);
+  temp2 = _mm_aeskeygenassist_si128 (temp1,0x4);
+  temp1 = AES_128_ASSIST(temp1, temp2);
+  Key_Schedule[3] = _mm512_broadcast_i32x4(temp1);
+  temp2 = _mm_aeskeygenassist_si128 (temp1,0x8);
+  temp1 = AES_128_ASSIST(temp1, temp2);
+  Key_Schedule[4] = _mm512_broadcast_i32x4(temp1);
+  temp2 = _mm_aeskeygenassist_si128 (temp1,0x10);
+  temp1 = AES_128_ASSIST(temp1, temp2);
+  Key_Schedule[5] = _mm512_broadcast_i32x4(temp1);
+  temp2 = _mm_aeskeygenassist_si128 (temp1,0x20);
+  temp1 = AES_128_ASSIST(temp1, temp2);
+  Key_Schedule[6] = _mm512_broadcast_i32x4(temp1);
+  temp2 = _mm_aeskeygenassist_si128 (temp1,0x40);
+  temp1 = AES_128_ASSIST(temp1, temp2);
+  Key_Schedule[7] = _mm512_broadcast_i32x4(temp1);
+  temp2 = _mm_aeskeygenassist_si128 (temp1,0x80);
+  temp1 = AES_128_ASSIST(temp1, temp2);
+  Key_Schedule[8] = _mm512_broadcast_i32x4(temp1);
+  temp2 = _mm_aeskeygenassist_si128 (temp1,0x1b);
+  temp1 = AES_128_ASSIST(temp1, temp2);
+  Key_Schedule[9] = _mm512_broadcast_i32x4(temp1);
+  temp2 = _mm_aeskeygenassist_si128 (temp1,0x36);
+  temp1 = AES_128_ASSIST(temp1, temp2);
+  Key_Schedule[10] = _mm512_broadcast_i32x4(temp1);
+}
+
+__m512i AES(const __m512i *Ki, __m512i x) {
+  x ^= Ki[0];
+  x = _mm512_aesenc_epi128(x, Ki[1]);
+  x = _mm512_aesenc_epi128(x, Ki[2]);
+  x = _mm512_aesenc_epi128(x, Ki[3]);
+  x = _mm512_aesenc_epi128(x, Ki[4]);
+  x = _mm512_aesenc_epi128(x, Ki[5]);
+  x = _mm512_aesenc_epi128(x, Ki[6]);
+  x = _mm512_aesenc_epi128(x, Ki[7]);
+  x = _mm512_aesenc_epi128(x, Ki[8]);
+  x = _mm512_aesenc_epi128(x, Ki[9]);
+  x = _mm512_aesenclast_epi128(x, Ki[10]);
+  return x;
+}
+
+__m512i AES_modified(const __m512i *Ki, __m512i x) {
+  x ^= Ki[0];
+  x = _mm512_aesenc_epi128(x, Ki[1]);
+  x = _mm512_aesenc_epi128(x, Ki[2]);
+  x = _mm512_aesenc_epi128(x, Ki[3]);
+  x = _mm512_aesenc_epi128(x, Ki[4]);
+  x = _mm512_aesenc_epi128(x, Ki[5]);
+  x = _mm512_aesenc_epi128(x, Ki[6]);
+  x = _mm512_aesenc_epi128(x, Ki[7]);
+  x = _mm512_aesenc_epi128(x, Ki[8]);
+  x = _mm512_aesenc_epi128(x, Ki[9]);
+  x = _mm512_aesenc_epi128(x, _mm512_set_epi64(0,0,0,0,0,0,0,0));
+  return x;
+}
+
+void lemac_x4_init(context *ctx, const uint8_t k[]) {
+  const __m128i *K = (__m128i*)k;
+
+  // Mask is <number of lanes - 1> || <lane id> || 0*
+  const uint64_t mask0 = (0x03ULL << 56) | (0x00ULL << 48);
+  const uint64_t mask1 = (0x03ULL << 56) | (0x01ULL << 48);
+  const uint64_t mask2 = (0x03ULL << 56) | (0x02ULL << 48);
+  const uint64_t mask3 = (0x03ULL << 56) | (0x03ULL << 48);
+  __m512i Ki[11];
+  AES_KS(*K, Ki);
+
+  // Kinit 0 --> 8
+  for (unsigned i=0; i<tabsize(ctx->init.S); i++)
+    ctx->init.S[i] = AES(Ki, _mm512_set_epi64(mask0,i,mask1,i,mask2,i,mask3,i));
+
+  // Kinit 9 --> 26
+  for (unsigned i=0; i<tabsize(ctx->subkeys); i++)
+    ctx->subkeys[i] = AES(Ki, _mm512_set_epi64(mask0,i+tabsize(ctx->init.S),
+                                               mask1,i+tabsize(ctx->init.S),
+                                               mask2,i+tabsize(ctx->init.S),
+                                               mask3,i+tabsize(ctx->init.S)));
+
+  // k2 27
+  AES_KS(_mm512_castsi512_si128(AES(Ki, _mm512_set_epi64(mask0,tabsize(ctx->init.S)+tabsize(ctx->subkeys),
+                                                         mask1,tabsize(ctx->init.S)+tabsize(ctx->subkeys),
+                                                         mask2,tabsize(ctx->init.S)+tabsize(ctx->subkeys),
+                                                         mask3,tabsize(ctx->init.S)+tabsize(ctx->subkeys)))), ctx->keys[0]);
+
+  // k3 28
+  AES_KS(_mm512_castsi512_si128(AES(Ki, _mm512_set_epi64(mask0,tabsize(ctx->init.S)+tabsize(ctx->subkeys)+1,
+                                                         mask1,tabsize(ctx->init.S)+tabsize(ctx->subkeys)+1,
+                                                         mask2,tabsize(ctx->init.S)+tabsize(ctx->subkeys)+1,
+                                                         mask3,tabsize(ctx->init.S)+tabsize(ctx->subkeys)+1))), ctx->keys[1]);
+}
+
+
+#define ROUND(S, M0, M1, M2, M3, RR, R0, R1, R2) do {   \
+    __m512i T = S.S[8];                                                     \
+    S.S[8] = _mm512_aesenc_epi128(S.S[7],M3);                   \
+    S.S[7] = _mm512_aesenc_epi128(S.S[6],M1);                   \
+    S.S[6] = _mm512_aesenc_epi128(S.S[5],M1);                   \
+    S.S[5] = _mm512_aesenc_epi128(S.S[4],M0);                   \
+    S.S[4] = _mm512_aesenc_epi128(S.S[3],M0);                   \
+    S.S[3] = _mm512_aesenc_epi128(S.S[2],R1 ^ R2);              \
+    S.S[2] = _mm512_aesenc_epi128(S.S[1],M3);                   \
+    S.S[1] = _mm512_aesenc_epi128(S.S[0],M3);                   \
+    S.S[0] = S.S[0] ^ T ^ M2;                                           \
+    R2 = R1;                                                    \
+    R1 = R0;                                                    \
+    R0 = RR ^ M1;                                               \
+    RR = M2;                                                    \
+  } while (0);
+
+state lemac_x4_AU(context *ctx, const uint8_t *m, size_t mlen, const __m512i N) {
+  /* state S = ctx->init; */
+  // Padding
+  size_t m_padded_len = mlen - (mlen % 256) + 256;
+  uint8_t m_padding[256];
+  memcpy(m_padding, m + (mlen / 256) * 256, mlen % 256);
+  m_padding[mlen % 256] = 1;
+  __m512i *M_padding = (__m512i*) m_padding;
+  for (size_t i = 1 + (mlen % 256); i < 256; ++i){
+    m_padding[i] = 0;
+  }
+
+  const __m512i *M = (__m512i*)m;
+  __m512i *Mfin = (__m512i*)(m + m_padded_len - 256);
+
+  state S = ctx->init;
+
+  __m512i RR = STATE_0;
+  __m512i R0 = STATE_0;
+  __m512i R1 = STATE_0;
+  __m512i R2 = STATE_0;
+  // Main rounds
+  for (;M < Mfin; M+=4) {
+    ROUND(S, M[0], M[1], M[2], M[3], RR, R0, R1, R2);
+  }
+
+  // Last round (padding)
+  ROUND(S, M_padding[0], M_padding[1], M_padding[2], M_padding[3], RR, R0, R1, R2);
+
+  // Four final rounds to absorb message state
+  ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
+  ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
+  ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
+  ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
+
+  // Absorb the tag from all the lanes into lane 0
+  // Lanes > 0 are then not used any more, but keep using 512-bit vectors for simplicity
+  __m512i T = N ^ AES(ctx->keys[0], N);
+  T ^= AES_modified(ctx->subkeys  , S.S[0]);
+  T ^= AES_modified(ctx->subkeys+1, S.S[1]);
+  T ^= AES_modified(ctx->subkeys+2, S.S[2]);
+  T ^= AES_modified(ctx->subkeys+3, S.S[3]);
+  T ^= AES_modified(ctx->subkeys+4, S.S[4]);
+  T ^= AES_modified(ctx->subkeys+5, S.S[5]);
+  T ^= AES_modified(ctx->subkeys+6, S.S[6]);
+  T ^= AES_modified(ctx->subkeys+7, S.S[7]);
+  T ^= AES_modified(ctx->subkeys+8, S.S[8]);
+
+  const __m512i T0 = _mm512_broadcast_i32x4(_mm512_extracti32x4_epi32(T, 0));
+  const __m512i T1 = _mm512_broadcast_i32x4(_mm512_extracti32x4_epi32(T, 1));
+  const __m512i T2 = _mm512_broadcast_i32x4(_mm512_extracti32x4_epi32(T, 2));
+  const __m512i T3 = _mm512_broadcast_i32x4(_mm512_extracti32x4_epi32(T, 3));
+  ROUND(S, T0, T1, T2, T3, RR, R0, R1, R2);
+  ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
+  ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
+  ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
+  ROUND(S, STATE_0, STATE_0, STATE_0, STATE_0, RR, R0, R1, R2);
+
+  return S;
+}
+
+void lemac_x4_MAC(context *ctx, const uint8_t *nonce, const uint8_t *m, size_t mlen, uint8_t *tag) {
+  const __m512i N = _mm512_broadcast_i32x4(*(const __m128i *) nonce);
+  state S = lemac_x4_AU(ctx, m, mlen, N);
+
+  __m512i T = N ^ AES(ctx->keys[0], N);
+  T ^= AES_modified(ctx->subkeys  , S.S[0]);
+  T ^= AES_modified(ctx->subkeys+1, S.S[1]);
+  T ^= AES_modified(ctx->subkeys+2, S.S[2]);
+  T ^= AES_modified(ctx->subkeys+3, S.S[3]);
+  T ^= AES_modified(ctx->subkeys+4, S.S[4]);
+  T ^= AES_modified(ctx->subkeys+5, S.S[5]);
+  T ^= AES_modified(ctx->subkeys+6, S.S[6]);
+  T ^= AES_modified(ctx->subkeys+7, S.S[7]);
+  T ^= AES_modified(ctx->subkeys+8, S.S[8]);
+
+  *(__m128i*)tag = _mm512_castsi512_si128(AES(ctx->keys[1], T));
+}

--- a/benchmark/LeMac-X4/lemac-x4.c
+++ b/benchmark/LeMac-X4/lemac-x4.c
@@ -196,11 +196,10 @@ state lemac_x4_AU(context *ctx, const uint8_t *m, size_t mlen) {
 }
 
 void lemac_x4_MAC(context *ctx, const uint8_t *nonce, const uint8_t *m, size_t mlen, uint8_t *tag) {
-  const __m512i N = _mm512_broadcast_i32x4(*(const __m128i *) nonce);
   state S = lemac_x4_AU(ctx, m, mlen);
 
-  __m512i T = N ^ AES(ctx->keys[0], N);
-  T ^= AES_modified(ctx->subkeys  , S.S[0]);
+  __m512i T;
+  T  = AES_modified(ctx->subkeys  , S.S[0]);
   T ^= AES_modified(ctx->subkeys+1, S.S[1]);
   T ^= AES_modified(ctx->subkeys+2, S.S[2]);
   T ^= AES_modified(ctx->subkeys+3, S.S[3]);
@@ -209,9 +208,15 @@ void lemac_x4_MAC(context *ctx, const uint8_t *nonce, const uint8_t *m, size_t m
   T ^= AES_modified(ctx->subkeys+6, S.S[6]);
   T ^= AES_modified(ctx->subkeys+7, S.S[7]);
   T ^= AES_modified(ctx->subkeys+8, S.S[8]);
-  T = _mm512_broadcast_i32x4(_mm_xor_si128(_mm_xor_si128(_mm_xor_si128
-                              (_mm512_extracti32x4_epi32(T, 0),  _mm512_extracti32x4_epi32(T, 1)),
-                               _mm512_extracti32x4_epi32(T, 2)), _mm512_extracti32x4_epi32(T, 3)));
 
-  *(__m128i*)tag = _mm512_castsi512_si128(AES(ctx->keys[1], T));
+  __m128i T_128 = _mm_xor_si128(_mm_xor_si128(_mm_xor_si128(
+                    _mm512_extracti32x4_epi32(T, 0),  _mm512_extracti32x4_epi32(T, 1)),
+                    _mm512_extracti32x4_epi32(T, 2)), _mm512_extracti32x4_epi32(T, 3));
+
+  const __m128i N = *(const __m128i *) nonce;
+  __m512i N_512 = _mm512_broadcast_i32x4(N);
+  __m128i nonce_contrib = _mm512_castsi512_si128(AES(ctx->keys[0], N_512));
+  T_128 ^= N ^ nonce_contrib;
+
+  *(__m128i*)tag = _mm512_castsi512_si128(AES(ctx->keys[1], _mm512_broadcast_i32x4(T_128)));
 }

--- a/benchmark/LeMac/Makefile
+++ b/benchmark/LeMac/Makefile
@@ -1,3 +1,11 @@
-CFLAGS= -Wall -Wextra -O3 -march=native
+CFLAGS= -Wall -Wextra -O3 -march=native -fno-lto
 
-bench:
+all: bench
+
+bench: bench.c
+	$(CC) $(CFLAGS) -o $@ $^
+
+clean:
+	rm -f bench *.o
+
+.PHONY: all clean

--- a/benchmark/LeMac/bench.c
+++ b/benchmark/LeMac/bench.c
@@ -100,7 +100,10 @@ int main() {
   int cycles[1000];
   uint8_t Z = 0;
   for (int i=0; i<1000; i++) {
-    getrandom(N, sizeof(N), 0);
+    if (getrandom(N, sizeof(N), 0) != sizeof(N)) {
+      fprintf(stderr, "getrandom failed\n");
+      exit(1);
+    }
 #ifdef PERF_EV
     ioctl(fd, PERF_EVENT_IOC_RESET, 0);
     ioctl(fd, PERF_EVENT_IOC_ENABLE, 0);

--- a/benchmark/PetitMAC/bench.c
+++ b/benchmark/PetitMAC/bench.c
@@ -100,7 +100,10 @@ int main() {
   int cycles[1000];
   uint8_t Z = 0;
   for (int i=0; i<1000; i++) {
-    getrandom(N, sizeof(N), 0);
+    if (getrandom(N, sizeof(N), 0) != sizeof(N)) {
+      fprintf(stderr, "getrandom failed\n");
+      exit(1);
+    }
 #ifdef PERF_EV
     ioctl(fd, PERF_EVENT_IOC_RESET, 0);
     ioctl(fd, PERF_EVENT_IOC_ENABLE, 0);

--- a/benchmark/aegis128l/encrypt.c
+++ b/benchmark/aegis128l/encrypt.c
@@ -237,7 +237,7 @@ int crypto_aead_encrypt(
     aegis128L_initialization(k, npub, state); 
 
     //process the associated data 
-    for (i = 0; (i+128) <= adlen; i = i+128)   
+    for (i = 0; (i+32) <= adlen; i = i+32)
     {   
         //The first 32-byte    
         msg0 = _mm_loadu_si128((__m128i*)(ad+i));
@@ -259,72 +259,14 @@ int crypto_aead_encrypt(
         state[4] = _mm_xor_si128(state[4],msg1);  
 
         
-        //The second 32-byte 
-        msg2 = _mm_loadu_si128((__m128i*)(ad+i+32));
-        msg3 = _mm_loadu_si128((__m128i*)(ad+i+48));
-
-        //state update function
-        tmp = state[7];
-        state[7] = _mm_aesenc_si128(state[6],state[7]);
-        state[6] = _mm_aesenc_si128(state[5],state[6]);
-        state[5] = _mm_aesenc_si128(state[4],state[5]);
-        state[4] = _mm_aesenc_si128(state[3],state[4]);
-        state[3] = _mm_aesenc_si128(state[2],state[3]);
-        state[2] = _mm_aesenc_si128(state[1],state[2]);
-        state[1] = _mm_aesenc_si128(state[0],state[1]);
-        state[0] = _mm_aesenc_si128(tmp,state[0]);
-
-        //message is used to update the state.
-        state[0] = _mm_xor_si128(state[0],msg2);
-        state[4] = _mm_xor_si128(state[4],msg3);    
-
-
-        //The third 32-byte    
-        msg0 = _mm_loadu_si128((__m128i*)(ad+i+64));
-        msg1 = _mm_loadu_si128((__m128i*)(ad+i+80));
-
-        //state update function
-        tmp = state[7];
-        state[7] = _mm_aesenc_si128(state[6],state[7]);
-        state[6] = _mm_aesenc_si128(state[5],state[6]);
-        state[5] = _mm_aesenc_si128(state[4],state[5]);
-        state[4] = _mm_aesenc_si128(state[3],state[4]);
-        state[3] = _mm_aesenc_si128(state[2],state[3]);
-        state[2] = _mm_aesenc_si128(state[1],state[2]);
-        state[1] = _mm_aesenc_si128(state[0],state[1]);
-        state[0] = _mm_aesenc_si128(tmp,state[0]);
-
-        //message is used to update the state.
-        state[0] = _mm_xor_si128(state[0],msg0);
-        state[4] = _mm_xor_si128(state[4],msg1);  
-
-        
-        //The fourth 32-byte 
-        msg2 = _mm_loadu_si128((__m128i*)(ad+i+96));
-        msg3 = _mm_loadu_si128((__m128i*)(ad+i+112));
-
-        //state update function
-        tmp = state[7];
-        state[7] = _mm_aesenc_si128(state[6],state[7]);
-        state[6] = _mm_aesenc_si128(state[5],state[6]);
-        state[5] = _mm_aesenc_si128(state[4],state[5]);
-        state[4] = _mm_aesenc_si128(state[3],state[4]);
-        state[3] = _mm_aesenc_si128(state[2],state[3]);
-        state[2] = _mm_aesenc_si128(state[1],state[2]);
-        state[1] = _mm_aesenc_si128(state[0],state[1]);
-        state[0] = _mm_aesenc_si128(tmp,state[0]);
-
-        //message is used to update the state.
-        state[0] = _mm_xor_si128(state[0],msg2);
-        state[4] = _mm_xor_si128(state[4],msg3);    
      }  
 
     // Deal with the partial block    
     // In this program, we assume that the message length is multiple of bytes.
     if (  (adlen & 0x7f) != 0 ) aegis128L_ad_partial(state, ad + i, adlen & 0x7f);     
 
-    // encrypt the message  
-    for (i = 0; (i+128) <= mlen; i = i+128) 
+    // encrypt the message
+    for (i = 0; (i+64) <= mlen; i = i+64)
     {   
         //encrypt 32 bytes: the first  
         msg0 = _mm_loadu_si128((__m128i*)(m+i)); 

--- a/benchmark/tiaoxin/Makefile
+++ b/benchmark/tiaoxin/Makefile
@@ -1,3 +1,11 @@
-CFLAGS= -Wall -Wextra -O3 -march=native
+CFLAGS= -Wall -Wextra -O3 -march=native -fno-lto
 
-bench: bench.o tiaoxin-optimized.o
+all: bench
+
+bench: bench.c
+	$(CC) $(CFLAGS) -o $@ $^
+
+clean:
+	rm -f bench *.o
+
+.PHONY: all clean


### PR DESCRIPTION
Only for benchmarking purposes.

Parallel variants run multiple LeMAC instances simultaneously:

- 2 instances for AVX2+VAES
- 4 instances for AVX512

Each instance runs with a distinct initial state.

Context separation is achieved by setting the top half of the counter (used for initializing states and keys) to `<number of lanes> || <lane number> || 0*`
similar to the approach used in the parallel variants of AEGIS.

With a parallelism degree of 1, the initialization function is identical to that of regular LeMAC.

Finalization is performed by absorbing the tags from all lanes into the first lane, and computing the final tag from this consolidated first lane using the standard LeMAC function.

These constructions are not intended for practical deployment but are useful for measuring the performance impact of leveraging VAES instructions.