### PR TITLE
benchmark: add EliMAC, aegis128x2, HiAE and smac1x8

### DIFF
--- a/benchmark/EliMAC/Makefile
+++ b/benchmark/EliMAC/Makefile
@@ -1,0 +1,3 @@
+CFLAGS= -Wall -Wextra -O3 -march=native
+
+bench:

--- a/benchmark/EliMAC/bench.c
+++ b/benchmark/EliMAC/bench.c
@@ -1,0 +1,134 @@
+#include <stdint.h>
+#include <stdio.h>
+
+#include "elimac.c"
+
+// Getrandom
+# if __GLIBC__ > 2 || __GLIBC_MINOR__ > 24
+
+#include <sys/random.h>
+
+#else /* older glibc */
+
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <errno.h>
+
+int getrandom(void *buf, size_t buflen, unsigned int flags) {
+    return syscall(SYS_getrandom, buf, buflen, flags);
+}
+# endif
+
+#ifndef MSIZE
+#define MSIZE 1*1024
+#endif
+
+void setrandom(void* buf, size_t buflen) {
+  size_t l = getrandom(buf, buflen, 0);
+  if (l != buflen) {
+    fprintf(stderr, "Error initializing random state\n");
+    exit(EXIT_FAILURE);
+  }
+}
+
+// Uncomment to use perf_event_open for benchmarks
+// #define PERF_EV
+
+
+// Uncomment to use rdpmc for benchmarks -- this requires running with perf stat -e cycles:u
+// #define USE_RDPMC
+
+
+#ifdef PERF_EV
+// Sample code from perf_event_open manpage
+
+#include <linux/perf_event.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+static long
+perf_event_open(struct perf_event_attr *hw_event, pid_t pid,
+                int cpu, int group_fd, unsigned long flags)
+{
+  int ret;
+
+  ret = syscall(SYS_perf_event_open, hw_event, pid, cpu,
+                group_fd, flags);
+  return ret;
+}
+#endif
+
+int main() {
+  uint8_t *M  = calloc(MSIZE,1);
+  uint8_t  K[32];
+  uint8_t  T[16];
+
+#ifdef PERF_EV
+  int                     fd;
+  long long               count;
+  struct perf_event_attr  pe;
+
+  memset(&pe, 0, sizeof(pe));
+  pe.type = PERF_TYPE_HARDWARE;
+  pe.size = sizeof(pe);
+  pe.config = PERF_COUNT_HW_CPU_CYCLES;
+  pe.disabled = 1;
+  pe.exclude_kernel = 1;
+  pe.exclude_hv = 1;
+
+  fd = perf_event_open(&pe, 0, -1, -1, 0);
+  if (fd == -1) {
+    fprintf(stderr, "Error opening leader %llx\n", pe.config);
+    exit(EXIT_FAILURE);
+  }
+#endif
+
+  setrandom(M, MSIZE);
+  setrandom(K, sizeof(K));
+
+  elimac_state st;
+
+  if (elimac_init(&st, K, MSIZE) != 0) {
+      exit(1);
+  }
+
+  // Blank computation
+  elimac_mac(&st, T, M, MSIZE);
+
+  // Benchmarks
+  int cycles[1000];
+  for (int i=0; i<1000; i++) {
+#ifdef PERF_EV
+    ioctl(fd, PERF_EVENT_IOC_RESET, 0);
+    ioctl(fd, PERF_EVENT_IOC_ENABLE, 0);
+#else
+#ifdef USE_RDPMC
+    unsigned long long start = __builtin_ia32_rdpmc(0);
+    _mm_lfence();
+#else
+    uint32_t tmp;
+    unsigned long long start = __builtin_ia32_rdtscp (&tmp);
+#endif
+#endif
+    elimac_mac(&st, T, M, MSIZE);
+#ifdef PERF_EV
+    ioctl(fd, PERF_EVENT_IOC_DISABLE, 0);
+    read(fd, &count, sizeof(count));
+    cycles[i] = count;
+#else
+#ifdef USE_RDPMC
+    _mm_lfence();
+    unsigned long long stop = __builtin_ia32_rdpmc(0);
+#else
+    unsigned long long stop = __builtin_ia32_rdtscp (&tmp);
+#endif
+    cycles[i] = stop-start;
+#endif
+  }
+
+  for (int i=0; i<1000; i++) {
+    printf ("%5.3f\n", 1.0*cycles[i]/(MSIZE));
+  }
+}

--- a/benchmark/EliMAC/elimac.c
+++ b/benchmark/EliMAC/elimac.c
@@ -1,0 +1,237 @@
+#include <errno.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define elimac_KEYBYTES 32
+#define elimac_MACBYTES 16
+
+#ifndef CRYPTO_ALIGN
+#    if defined(__INTEL_COMPILER) || defined(_MSC_VER)
+#        define CRYPTO_ALIGN(x) __declspec(align(x))
+#    else
+#        define CRYPTO_ALIGN(x) __attribute__((aligned(x)))
+#    endif
+#endif
+
+typedef struct elimac_state {
+    CRYPTO_ALIGN(64) uint8_t opaque[1024];
+} elimac_state;
+
+#if !defined(MSC_VER) || _MSC_VER < 1800
+#    define __vectorcall
+#endif
+
+#define COMPILER_ASSERT(X) (void) sizeof(char[(X) ? 1 : -1])
+
+#ifdef __clang__
+#    pragma clang attribute push(__attribute__((target("aes,avx"))), apply_to = function)
+#elif defined(__GNUC__)
+#    pragma GCC target("aes,avx")
+#endif
+
+#include <immintrin.h>
+
+typedef __m128i BlockVec;
+
+#define LOAD128(a)                 _mm_loadu_si128((const BlockVec *) (a))
+#define STORE128(a, b)             _mm_storeu_si128((BlockVec *) (a), (b))
+#define SET64x2(a, b)              _mm_set_epi64x((uint64_t) (a), (uint64_t) (b))
+#define ZERO128                    _mm_setzero_si128()
+#define ADD64x2(a, b)              _mm_add_epi64((a), (b))
+#define XOR128(a, b)               _mm_xor_si128((a), (b))
+#define SHUFFLE32x4(x, a, b, c, d) _mm_shuffle_epi32((x), _MM_SHUFFLE((d), (c), (b), (a)))
+#define BYTESHL128(a, b)           _mm_slli_si128(a, b)
+
+#define AES_ENCRYPT(block_vec, rkey)     _mm_aesenc_si128((block_vec), (rkey))
+#define AES_ENCRYPTLAST(block_vec, rkey) _mm_aesenclast_si128((block_vec), (rkey))
+#define AES_KEYGEN(block_vec, rc)        _mm_aeskeygenassist_si128((block_vec), (rc))
+
+#ifndef elimac_PARALLELISM
+#    define elimac_PARALLELISM 10
+#endif
+
+#define elimac_H_ROUNDS 7
+#define elimac_E_ROUNDS 10
+#define elimac_I_ROUNDS 4
+
+typedef struct EliMac {
+    BlockVec  i_rks[1 + elimac_I_ROUNDS];
+    BlockVec  e_rks[1 + elimac_E_ROUNDS];
+    BlockVec *i_keys;
+    size_t    max_length;
+} EliMac;
+
+#define elimac_STATE_ALIGN 16
+
+static void __vectorcall expand128(BlockVec key, BlockVec *rkeys, const int rounds)
+{
+    BlockVec s;
+    size_t   i = 0;
+
+#define EXPAND_KEY(RC)                            \
+    rkeys[i++] = key;                             \
+    s          = AES_KEYGEN(key, RC);             \
+    key        = XOR128(key, BYTESHL128(key, 4)); \
+    key        = XOR128(key, BYTESHL128(key, 8)); \
+    key        = XOR128(key, SHUFFLE32x4(s, 3, 3, 3, 3));
+
+    EXPAND_KEY(0x01);
+    EXPAND_KEY(0x02);
+    EXPAND_KEY(0x04);
+    EXPAND_KEY(0x08);
+    if (rounds > 4) {
+        EXPAND_KEY(0x10);
+        EXPAND_KEY(0x20);
+        EXPAND_KEY(0x40);
+    }
+    if (rounds > 7) {
+        EXPAND_KEY(0x80);
+        EXPAND_KEY(0x1b);
+        EXPAND_KEY(0x36);
+    }
+    rkeys[i++] = key;
+}
+
+int
+elimac_init(elimac_state *st_, const uint8_t key[elimac_KEYBYTES], size_t max_length)
+{
+    EliMac *const st = (EliMac *) ((((uintptr_t) &st_->opaque) + (elimac_STATE_ALIGN - 1)) &
+                                   ~(uintptr_t) (elimac_STATE_ALIGN - 1));
+    COMPILER_ASSERT((sizeof *st) + elimac_STATE_ALIGN <= sizeof *st_);
+
+    if ((max_length >> 32) != 0) {
+        errno = E2BIG;
+        return -1;
+    }
+    st->max_length          = max_length;
+    const size_t max_blocks = (max_length + 15) / 16;
+
+    st->i_keys = aligned_alloc(16, max_blocks * sizeof(BlockVec));
+    if (st->i_keys == NULL) {
+        return -1;
+    }
+
+    const BlockVec h_key = LOAD128(&key[0]);
+    const BlockVec e_key = LOAD128(&key[16]);
+
+    BlockVec h_rks[1 + elimac_H_ROUNDS];
+    expand128(h_key, h_rks, elimac_H_ROUNDS);
+    expand128(ZERO128, st->i_rks, elimac_I_ROUNDS);
+    expand128(e_key, st->e_rks, elimac_E_ROUNDS);
+
+    BlockVec       ctr  = ZERO128;
+    const BlockVec incr = SET64x2(0x00010001, 0x00010001);
+    for (size_t i = 0; i < max_blocks; i++) {
+        BlockVec i_key;
+
+        ctr = ADD64x2(ctr, incr);
+
+        i_key = XOR128(ctr, h_rks[0]);
+        for (size_t j = 1; j < elimac_H_ROUNDS - 1; j++) {
+            i_key = AES_ENCRYPT(i_key, h_rks[j]);
+        }
+        i_key = AES_ENCRYPTLAST(i_key, h_rks[elimac_H_ROUNDS]);
+
+        st->i_keys[i] = i_key;
+    }
+    return 0;
+}
+
+void
+elimac_free(elimac_state *st_)
+{
+    EliMac *const st = (EliMac *) ((((uintptr_t) &st_->opaque) + (elimac_STATE_ALIGN - 1)) &
+                                   ~(uintptr_t) (elimac_STATE_ALIGN - 1));
+    free(st->i_keys);
+    st->i_keys = NULL;
+}
+
+int
+elimac_mac(const elimac_state *st_, uint8_t tag[elimac_MACBYTES], const uint8_t *message,
+           size_t length)
+{
+    const EliMac *const st = (EliMac *) ((((uintptr_t) &st_->opaque) + (elimac_STATE_ALIGN - 1)) &
+                                         ~(uintptr_t) (elimac_STATE_ALIGN - 1));
+
+    memset(tag, 0, elimac_MACBYTES);
+    if (length > st->max_length) {
+        errno = E2BIG;
+        return -1;
+    }
+
+#if elimac_PARALLELISM > 1
+
+    BlockVec accs[elimac_PARALLELISM];
+    for (size_t i = 0; i < elimac_PARALLELISM; i++) {
+        accs[i] = ZERO128;
+    }
+
+    size_t i = 0;
+    for (; i + elimac_PARALLELISM * 16 <= length; i += elimac_PARALLELISM * 16) {
+        const BlockVec k = st->i_keys[i / 16];
+        BlockVec       kx[elimac_PARALLELISM];
+
+        for (size_t j = 0; j < elimac_PARALLELISM; j++) {
+            kx[j] = XOR128(k, LOAD128(&message[i + j * 16]));
+            kx[j] = XOR128(kx[j], st->i_rks[0]);
+        }
+        for (size_t j = 1; j < elimac_I_ROUNDS; j++) {
+            for (size_t k = 0; k < elimac_PARALLELISM; k++) {
+                kx[k] = AES_ENCRYPT(kx[k], st->i_rks[j]);
+            }
+        }
+        for (size_t j = 0; j < elimac_PARALLELISM; j++) {
+            kx[j] = AES_ENCRYPTLAST(kx[j], st->i_rks[elimac_I_ROUNDS]);
+        }
+
+        for (size_t j = 0; j < elimac_PARALLELISM; j++) {
+            accs[j] = XOR128(accs[j], kx[j]);
+        }
+    }
+
+    BlockVec acc = accs[0];
+    for (size_t j = 1; j < elimac_PARALLELISM; j++) {
+        acc = XOR128(acc, accs[j]);
+    }
+
+#else
+    size_t   i   = 0;
+    BlockVec acc = ZERO128;
+#endif
+
+    for (; i + 16 <= length; i += 16) {
+        const BlockVec k = st->i_keys[i / 16];
+        BlockVec       kx;
+
+        kx = XOR128(k, LOAD128(&message[i]));
+
+        kx = XOR128(kx, st->i_rks[0]);
+        for (size_t j = 1; j < elimac_I_ROUNDS; j++) {
+            kx = AES_ENCRYPT(kx, st->i_rks[j]);
+        }
+        kx = AES_ENCRYPTLAST(kx, st->i_rks[elimac_I_ROUNDS]);
+
+        acc = XOR128(acc, kx);
+    }
+    const size_t left       = length - i;
+    uint8_t      padded[16] = { 0 };
+    memcpy(padded, &message[i], left);
+    padded[left] = 0x80;
+    acc          = XOR128(acc, LOAD128(padded));
+
+    BlockVec t = XOR128(acc, st->e_rks[0]);
+    for (size_t j = 1; j < elimac_E_ROUNDS; j++) {
+        t = AES_ENCRYPT(t, st->e_rks[j]);
+    }
+    t = AES_ENCRYPTLAST(t, st->e_rks[elimac_E_ROUNDS]);
+
+    STORE128(tag, t);
+
+    return 0;
+}
+
+#ifdef __clang__
+#    pragma clang attribute pop
+#endif

--- a/benchmark/HiAE/Makefile
+++ b/benchmark/HiAE/Makefile
@@ -1,0 +1,3 @@
+CFLAGS= -Wall -Wextra -O3 -march=native
+
+bench:

--- a/benchmark/HiAE/bench.c
+++ b/benchmark/HiAE/bench.c
@@ -1,0 +1,132 @@
+#include <stdint.h>
+#include <stdio.h>
+
+#include "encrypt.c"
+
+// Getrandom
+# if __GLIBC__ > 2 || __GLIBC_MINOR__ > 24
+
+#include <sys/random.h>
+
+#else /* older glibc */
+
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <errno.h>
+
+int getrandom(void *buf, size_t buflen, unsigned int flags) {
+    return syscall(SYS_getrandom, buf, buflen, flags);
+}
+# endif
+
+#ifndef MSIZE
+#define MSIZE 1*1024
+#endif
+
+void setrandom(void* buf, size_t buflen) {
+  size_t l = getrandom(buf, buflen, 0);
+  if (l != buflen) {
+    fprintf(stderr, "Error initializing random state\n");
+    exit(EXIT_FAILURE);
+  }
+}
+
+// Uncomment to use perf_event_open for benchmarks
+// #define PERF_EV
+
+
+// Uncomment to use rdpmc for benchmarks -- this requires running with perf stat -e cycles:u
+// #define USE_RDPMC
+
+
+#ifdef PERF_EV
+// Sample code from perf_event_open manpage
+
+#include <linux/perf_event.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+static long
+perf_event_open(struct perf_event_attr *hw_event, pid_t pid,
+                int cpu, int group_fd, unsigned long flags)
+{
+  int ret;
+
+  ret = syscall(SYS_perf_event_open, hw_event, pid, cpu,
+                group_fd, flags);
+  return ret;
+}
+#endif
+
+int main() {
+  uint8_t *M  = calloc(MSIZE,1);
+  uint8_t  N[16];
+  uint8_t  K[16];
+  uint8_t  T[16];
+
+#ifdef PERF_EV
+  int                     fd;
+  long long               count;
+  struct perf_event_attr  pe;
+
+  memset(&pe, 0, sizeof(pe));
+  pe.type = PERF_TYPE_HARDWARE;
+  pe.size = sizeof(pe);
+  pe.config = PERF_COUNT_HW_CPU_CYCLES;
+  pe.disabled = 1;
+  pe.exclude_kernel = 1;
+  pe.exclude_hv = 1;
+
+  fd = perf_event_open(&pe, 0, -1, -1, 0);
+  if (fd == -1) {
+    fprintf(stderr, "Error opening leader %llx\n", pe.config);
+    exit(EXIT_FAILURE);
+  }
+#endif
+
+  setrandom(M, MSIZE);
+  setrandom(N, sizeof(N));
+  setrandom(K, sizeof(K));
+
+  // Blank computation
+  unsigned long long clen;
+  crypto_aead_encrypt(T, &clen, NULL, 0, M, MSIZE, NULL, N, K);
+
+
+  // Benchmarks
+  int cycles[1000];
+  for (int i=0; i<1000; i++) {
+#ifdef PERF_EV
+    ioctl(fd, PERF_EVENT_IOC_RESET, 0);
+    ioctl(fd, PERF_EVENT_IOC_ENABLE, 0);
+#else
+#ifdef USE_RDPMC
+    unsigned long long start = __builtin_ia32_rdpmc(0);
+    _mm_lfence();
+#else
+    uint32_t tmp;
+    unsigned long long start = __builtin_ia32_rdtscp (&tmp);
+#endif
+#endif
+    crypto_aead_encrypt(T, &clen, NULL, 0, M, MSIZE, NULL, N, K);
+#ifdef PERF_EV
+    ioctl(fd, PERF_EVENT_IOC_DISABLE, 0);
+    read(fd, &count, sizeof(count));
+    cycles[i] = count;
+#else
+#ifdef USE_RDPMC
+    _mm_lfence();
+    unsigned long long stop = __builtin_ia32_rdpmc(0);
+#else
+    unsigned long long stop = __builtin_ia32_rdtscp (&tmp);
+#endif
+    cycles[i] = stop-start;
+#endif
+  }
+
+  for (int i=0; i<1000; i++) {
+    printf ("%5.3f\n", 1.0*cycles[i]/(MSIZE));
+  }
+}

--- a/benchmark/HiAE/encrypt.c
+++ b/benchmark/HiAE/encrypt.c
@@ -1,0 +1,413 @@
+#include <stdint.h>
+#include <string.h>
+
+#define UNROLL_BLOCK_SIZE 256 // NUM of STATES * BLOCK_SIZE
+#define BLOCK_SIZE        16 // 128bits = 16 Bytes
+#define UNROLL_ROUND      16 // = NUM of STATES
+#define STATE             16 // NUM of STATES
+
+#if defined(__AES__) && defined(__x86_64__)
+#    include <immintrin.h>
+#    include <wmmintrin.h>
+typedef __m128i DATA128b;
+#elif defined(__ARM_FEATURE_CRYPTO) && defined(__ARM_NEON)
+#    include <arm_neon.h>
+typedef uint8x16_t DATA128b;
+#else
+#    error arch_not_supported_yet
+#endif
+
+#define P_0 0
+#define P_1 1
+#define P_4 13
+#define P_7 9
+#define i_1 3
+#define i_2 13
+
+static const uint8_t CONST0[16] = { 0x32, 0x43, 0xf6, 0xa8, 0x88, 0x5a, 0x30, 0x8d,
+                                    0x31, 0x31, 0x98, 0xa2, 0xe0, 0x37, 0x07, 0x34 };
+static const uint8_t CONST1[16] = { 0x4a, 0x40, 0x93, 0x82, 0x22, 0x99, 0xf3, 0x1d,
+                                    0x00, 0x82, 0xef, 0xa9, 0x8e, 0xc4, 0xe6, 0xc8 };
+
+#if defined(__AES__) && defined(__x86_64__)
+#    include <immintrin.h>
+#    include <wmmintrin.h>
+
+#    define SIMD_LOAD(x)     _mm_loadu_si128((const __m128i *) (x))
+#    define SIMD_STORE(x, y) _mm_storeu_si128((__m128i *) (x), y)
+#    define SIMD_XOR(x, y)   _mm_xor_si128(x, y)
+#    define SIMD_ZERO_128()  _mm_setzero_si128()
+#    define AESEMC(x, y)     _mm_aesenc_si128(SIMD_XOR(x, y), SIMD_ZERO_128())
+#    define AESL(x)          _mm_aesenc_si128(x, SIMD_ZERO_128())
+#    define AESENC(x, y)     _mm_aesenc_si128(x, y)
+
+#elif defined(__ARM_FEATURE_CRYPTO) && defined(__ARM_NEON)
+#    include <arm_neon.h>
+
+#    define SIMD_LOAD(x)       vld1q_u8(x)
+#    define SIMD_STORE(dst, x) vst1q_u8(dst, x)
+#    define SIMD_XOR(a, b)     veorq_u8(a, b)
+#    define SIMD_ZERO_128()    vmovq_n_u8(0)
+#    define AESEMC(x, y)       vaesmcq_u8(vaeseq_u8(x, y))
+#    define AESL(x)            AESEMC(x, SIMD_ZERO_128())
+#    define AESENC(x, y)       SIMD_XOR(AESEMC(x, SIMD_ZERO_128()), y)
+
+#else
+#    error This_Arch_do_not_Supported_yet_!!!
+#endif
+
+/*
+ * Avoid cost of extra XOR operation cross platform
+ */
+#if defined(__AES__) && defined(__x86_64__)
+
+#    define UPDATE_STATE_offset(M, offset)                                                    \
+        tmp[offset] = SIMD_XOR(state[(P_0 + offset) % STATE], state[(P_1 + offset) % STATE]); \
+        tmp[offset] = AESENC(tmp[offset], M);                                                 \
+        state[(0 + offset) % STATE]   = AESENC(state[(P_4 + offset) % STATE], tmp[offset]);   \
+        state[(i_1 + offset) % STATE] = SIMD_XOR(state[(i_1 + offset) % STATE], M);           \
+        state[(i_2 + offset) % STATE] = SIMD_XOR(state[(i_2 + offset) % STATE], M);
+
+#    define ENC_offset(M, C, offset)                                                \
+        C = SIMD_XOR(state[(P_0 + offset) % STATE], state[(P_1 + offset) % STATE]); \
+        C = AESENC(C, M);                                                           \
+        state[(0 + offset) % STATE]   = AESENC(state[(P_4 + offset) % STATE], C);   \
+        C                             = SIMD_XOR(C, state[(P_7 + offset) % STATE]); \
+        state[(i_1 + offset) % STATE] = SIMD_XOR(state[(i_1 + offset) % STATE], M); \
+        state[(i_2 + offset) % STATE] = SIMD_XOR(state[(i_2 + offset) % STATE], M);
+
+#    define DEC_offset(M, C, offset)                                                          \
+        tmp[offset] = SIMD_XOR(state[(P_0 + offset) % STATE], state[(P_1 + offset) % STATE]); \
+        M           = SIMD_XOR(state[(P_7 + offset) % STATE], C);                             \
+        state[(0 + offset) % STATE]   = AESENC(state[(P_4 + offset) % STATE], M);             \
+        M                             = AESENC(tmp[offset], M);                               \
+        state[(i_1 + offset) % STATE] = SIMD_XOR(state[(i_1 + offset) % STATE], M);           \
+        state[(i_2 + offset) % STATE] = SIMD_XOR(state[(i_2 + offset) % STATE], M);
+
+#elif defined(__ARM_FEATURE_CRYPTO) && defined(__ARM_NEON)
+
+#    define UPDATE_STATE_offset(M, offset)                                                          \
+        tmp[offset] = AESEMC(state[(P_0 + offset) % STATE], state[(P_1 + offset) % STATE]);         \
+        tmp[offset] = SIMD_XOR(tmp[offset], M);                                                     \
+        state[(0 + offset) % STATE]   = SIMD_XOR(tmp[offset], AESL(state[(P_4 + offset) % STATE])); \
+        state[(i_1 + offset) % STATE] = SIMD_XOR(state[(i_1 + offset) % STATE], M);                 \
+        state[(i_2 + offset) % STATE] = SIMD_XOR(state[(i_2 + offset) % STATE], M);
+
+#    define ENC_offset(M, C, offset)                                                        \
+        tmp[offset] = AESEMC(state[(P_0 + offset) % STATE], state[(P_1 + offset) % STATE]); \
+        C           = SIMD_XOR(tmp[offset], M);                                             \
+        state[(0 + offset) % STATE]   = SIMD_XOR(C, AESL(state[(P_4 + offset) % STATE]));   \
+        C                             = SIMD_XOR(C, state[(P_7 + offset) % STATE]);         \
+        state[(i_1 + offset) % STATE] = SIMD_XOR(state[(i_1 + offset) % STATE], M);         \
+        state[(i_2 + offset) % STATE] = SIMD_XOR(state[(i_2 + offset) % STATE], M);
+
+#    define DEC_offset(M, C, offset)                                                        \
+        tmp[offset] = AESEMC(state[(P_0 + offset) % STATE], state[(P_1 + offset) % STATE]); \
+        M           = SIMD_XOR(state[(P_7 + offset) % STATE], C);                           \
+        state[(0 + offset) % STATE]   = SIMD_XOR(M, AESL(state[(P_4 + offset) % STATE]));   \
+        M                             = SIMD_XOR(M, tmp[offset]);                           \
+        state[(i_1 + offset) % STATE] = SIMD_XOR(state[(i_1 + offset) % STATE], M);         \
+        state[(i_2 + offset) % STATE] = SIMD_XOR(state[(i_2 + offset) % STATE], M);
+
+#else
+
+#    error This_Arch_do_not_Supported_yet_!!!
+
+#endif
+
+/*
+ * load 4 128bit block from src
+ */
+#define LOAD_1BLOCK_offset(M, offset)                   \
+    (M) = SIMD_LOAD(src + i + 0 + BLOCK_SIZE * offset); \
+/*                                                      \
+ * store 4 128bit block to dst                          \
+ */
+#define STORE_1BLOCK_offset(C, offset) SIMD_STORE(dst + i + 0 + BLOCK_SIZE * offset, (C));
+
+#define encode_little_endian(bytes, v)           \
+    bytes[0]  = ((uint64_t) (v) << (3));         \
+    bytes[1]  = ((uint64_t) (v) >> (1 * 8 - 3)); \
+    bytes[2]  = ((uint64_t) (v) >> (2 * 8 - 3)); \
+    bytes[3]  = ((uint64_t) (v) >> (3 * 8 - 3)); \
+    bytes[4]  = ((uint64_t) (v) >> (4 * 8 - 3)); \
+    bytes[5]  = ((uint64_t) (v) >> (5 * 8 - 3)); \
+    bytes[6]  = ((uint64_t) (v) >> (6 * 8 - 3)); \
+    bytes[7]  = ((uint64_t) (v) >> (7 * 8 - 3)); \
+    bytes[8]  = ((uint64_t) (v) >> (8 * 8 - 3)); \
+    bytes[9]  = 0;                               \
+    bytes[10] = 0;                               \
+    bytes[11] = 0;                               \
+    bytes[12] = 0;                               \
+    bytes[13] = 0;                               \
+    bytes[14] = 0;                               \
+    bytes[15] = 0;
+
+#define STATE_SHIFT        \
+    tmp[0]    = state[0];  \
+    state[0]  = state[1];  \
+    state[1]  = state[2];  \
+    state[2]  = state[3];  \
+    state[3]  = state[4];  \
+    state[4]  = state[5];  \
+    state[5]  = state[6];  \
+    state[6]  = state[7];  \
+    state[7]  = state[8];  \
+    state[8]  = state[9];  \
+    state[9]  = state[10]; \
+    state[10] = state[11]; \
+    state[11] = state[12]; \
+    state[12] = state[13]; \
+    state[13] = state[14]; \
+    state[14] = state[15]; \
+    state[15] = tmp[0]
+
+#define INIT_UPDATE(c0)          \
+    UPDATE_STATE_offset(c0, 0);  \
+    UPDATE_STATE_offset(c0, 1);  \
+    UPDATE_STATE_offset(c0, 2);  \
+    UPDATE_STATE_offset(c0, 3);  \
+    UPDATE_STATE_offset(c0, 4);  \
+    UPDATE_STATE_offset(c0, 5);  \
+    UPDATE_STATE_offset(c0, 6);  \
+    UPDATE_STATE_offset(c0, 7);  \
+    UPDATE_STATE_offset(c0, 8);  \
+    UPDATE_STATE_offset(c0, 9);  \
+    UPDATE_STATE_offset(c0, 10); \
+    UPDATE_STATE_offset(c0, 11); \
+    UPDATE_STATE_offset(c0, 12); \
+    UPDATE_STATE_offset(c0, 13); \
+    UPDATE_STATE_offset(c0, 14); \
+    UPDATE_STATE_offset(c0, 15);
+
+#define AD_UPDATE                   \
+    LOAD_1BLOCK_offset(M[0], 0);    \
+    LOAD_1BLOCK_offset(M[1], 1);    \
+    LOAD_1BLOCK_offset(M[2], 2);    \
+    LOAD_1BLOCK_offset(M[3], 3);    \
+    LOAD_1BLOCK_offset(M[4], 4);    \
+    LOAD_1BLOCK_offset(M[5], 5);    \
+    LOAD_1BLOCK_offset(M[6], 6);    \
+    LOAD_1BLOCK_offset(M[7], 7);    \
+    LOAD_1BLOCK_offset(M[8], 8);    \
+    LOAD_1BLOCK_offset(M[9], 9);    \
+    LOAD_1BLOCK_offset(M[10], 10);  \
+    LOAD_1BLOCK_offset(M[11], 11);  \
+    LOAD_1BLOCK_offset(M[12], 12);  \
+    LOAD_1BLOCK_offset(M[13], 13);  \
+    LOAD_1BLOCK_offset(M[14], 14);  \
+    LOAD_1BLOCK_offset(M[15], 15);  \
+    UPDATE_STATE_offset(M[0], 0);   \
+    UPDATE_STATE_offset(M[1], 1);   \
+    UPDATE_STATE_offset(M[2], 2);   \
+    UPDATE_STATE_offset(M[3], 3);   \
+    UPDATE_STATE_offset(M[4], 4);   \
+    UPDATE_STATE_offset(M[5], 5);   \
+    UPDATE_STATE_offset(M[6], 6);   \
+    UPDATE_STATE_offset(M[7], 7);   \
+    UPDATE_STATE_offset(M[8], 8);   \
+    UPDATE_STATE_offset(M[9], 9);   \
+    UPDATE_STATE_offset(M[10], 10); \
+    UPDATE_STATE_offset(M[11], 11); \
+    UPDATE_STATE_offset(M[12], 12); \
+    UPDATE_STATE_offset(M[13], 13); \
+    UPDATE_STATE_offset(M[14], 14); \
+    UPDATE_STATE_offset(M[15], 15);
+
+#define ENCRYPT                     \
+    LOAD_1BLOCK_offset(M[0], 0);    \
+    LOAD_1BLOCK_offset(M[1], 1);    \
+    LOAD_1BLOCK_offset(M[2], 2);    \
+    LOAD_1BLOCK_offset(M[3], 3);    \
+    LOAD_1BLOCK_offset(M[4], 4);    \
+    LOAD_1BLOCK_offset(M[5], 5);    \
+    LOAD_1BLOCK_offset(M[6], 6);    \
+    LOAD_1BLOCK_offset(M[7], 7);    \
+    LOAD_1BLOCK_offset(M[8], 8);    \
+    LOAD_1BLOCK_offset(M[9], 9);    \
+    LOAD_1BLOCK_offset(M[10], 10);  \
+    LOAD_1BLOCK_offset(M[11], 11);  \
+    LOAD_1BLOCK_offset(M[12], 12);  \
+    LOAD_1BLOCK_offset(M[13], 13);  \
+    LOAD_1BLOCK_offset(M[14], 14);  \
+    LOAD_1BLOCK_offset(M[15], 15);  \
+    ENC_offset(M[0], C[0], 0);      \
+    ENC_offset(M[1], C[1], 1);      \
+    ENC_offset(M[2], C[2], 2);      \
+    ENC_offset(M[3], C[3], 3);      \
+    ENC_offset(M[4], C[4], 4);      \
+    ENC_offset(M[5], C[5], 5);      \
+    ENC_offset(M[6], C[6], 6);      \
+    ENC_offset(M[7], C[7], 7);      \
+    ENC_offset(M[8], C[8], 8);      \
+    ENC_offset(M[9], C[9], 9);      \
+    ENC_offset(M[10], C[10], 10);   \
+    ENC_offset(M[11], C[11], 11);   \
+    ENC_offset(M[12], C[12], 12);   \
+    ENC_offset(M[13], C[13], 13);   \
+    ENC_offset(M[14], C[14], 14);   \
+    ENC_offset(M[15], C[15], 15);   \
+    STORE_1BLOCK_offset(C[0], 0);   \
+    STORE_1BLOCK_offset(C[1], 1);   \
+    STORE_1BLOCK_offset(C[2], 2);   \
+    STORE_1BLOCK_offset(C[3], 3);   \
+    STORE_1BLOCK_offset(C[4], 4);   \
+    STORE_1BLOCK_offset(C[5], 5);   \
+    STORE_1BLOCK_offset(C[6], 6);   \
+    STORE_1BLOCK_offset(C[7], 7);   \
+    STORE_1BLOCK_offset(C[8], 8);   \
+    STORE_1BLOCK_offset(C[9], 9);   \
+    STORE_1BLOCK_offset(C[10], 10); \
+    STORE_1BLOCK_offset(C[11], 11); \
+    STORE_1BLOCK_offset(C[12], 12); \
+    STORE_1BLOCK_offset(C[13], 13); \
+    STORE_1BLOCK_offset(C[14], 14); \
+    STORE_1BLOCK_offset(C[15], 15);
+
+#define DECRYPT                     \
+    LOAD_1BLOCK_offset(C[0], 0);    \
+    LOAD_1BLOCK_offset(C[1], 1);    \
+    LOAD_1BLOCK_offset(C[2], 2);    \
+    LOAD_1BLOCK_offset(C[3], 3);    \
+    LOAD_1BLOCK_offset(C[4], 4);    \
+    LOAD_1BLOCK_offset(C[5], 5);    \
+    LOAD_1BLOCK_offset(C[6], 6);    \
+    LOAD_1BLOCK_offset(C[7], 7);    \
+    LOAD_1BLOCK_offset(C[8], 8);    \
+    LOAD_1BLOCK_offset(C[9], 9);    \
+    LOAD_1BLOCK_offset(C[10], 10);  \
+    LOAD_1BLOCK_offset(C[11], 11);  \
+    LOAD_1BLOCK_offset(C[12], 12);  \
+    LOAD_1BLOCK_offset(C[13], 13);  \
+    LOAD_1BLOCK_offset(C[14], 14);  \
+    LOAD_1BLOCK_offset(C[15], 15);  \
+    DEC_offset(M[0], C[0], 0);      \
+    DEC_offset(M[1], C[1], 1);      \
+    DEC_offset(M[2], C[2], 2);      \
+    DEC_offset(M[3], C[3], 3);      \
+    DEC_offset(M[4], C[4], 4);      \
+    DEC_offset(M[5], C[5], 5);      \
+    DEC_offset(M[6], C[6], 6);      \
+    DEC_offset(M[7], C[7], 7);      \
+    DEC_offset(M[8], C[8], 8);      \
+    DEC_offset(M[9], C[9], 9);      \
+    DEC_offset(M[10], C[10], 10);   \
+    DEC_offset(M[11], C[11], 11);   \
+    DEC_offset(M[12], C[12], 12);   \
+    DEC_offset(M[13], C[13], 13);   \
+    DEC_offset(M[14], C[14], 14);   \
+    DEC_offset(M[15], C[15], 15);   \
+    STORE_1BLOCK_offset(M[0], 0);   \
+    STORE_1BLOCK_offset(M[1], 1);   \
+    STORE_1BLOCK_offset(M[2], 2);   \
+    STORE_1BLOCK_offset(M[3], 3);   \
+    STORE_1BLOCK_offset(M[4], 4);   \
+    STORE_1BLOCK_offset(M[5], 5);   \
+    STORE_1BLOCK_offset(M[6], 6);   \
+    STORE_1BLOCK_offset(M[7], 7);   \
+    STORE_1BLOCK_offset(M[8], 8);   \
+    STORE_1BLOCK_offset(M[9], 9);   \
+    STORE_1BLOCK_offset(M[10], 10); \
+    STORE_1BLOCK_offset(M[11], 11); \
+    STORE_1BLOCK_offset(M[12], 12); \
+    STORE_1BLOCK_offset(M[13], 13); \
+    STORE_1BLOCK_offset(M[14], 14); \
+    STORE_1BLOCK_offset(M[15], 15);
+
+static void
+HiAE_stream_init(DATA128b *state, const uint8_t *key, const uint8_t *iv)
+{
+    DATA128b c0 = SIMD_LOAD(CONST0);
+    DATA128b c1 = SIMD_LOAD(CONST1);
+    DATA128b k0 = SIMD_LOAD(key);
+    DATA128b k1 = SIMD_LOAD(key + 16);
+    DATA128b N  = SIMD_LOAD(iv);
+
+    DATA128b ze = SIMD_ZERO_128();
+    state[0]    = c0;
+    state[1]    = k1;
+    state[2]    = N;
+    state[3]    = c0;
+    state[4]    = ze;
+    state[5]    = SIMD_XOR(N, k0);
+    state[6]    = ze;
+    state[7]    = c1;
+    state[8]    = SIMD_XOR(N, k1);
+    state[9]    = ze;
+    state[10]   = k1;
+    state[11]   = c0;
+    state[12]   = c1;
+    state[13]   = k1;
+    state[14]   = ze;
+    state[15]   = SIMD_XOR(c0, c1);
+
+    DATA128b tmp[STATE];
+    INIT_UPDATE(c0);
+    INIT_UPDATE(c0);
+    state[9]  = SIMD_XOR(state[9], k0);
+    state[13] = SIMD_XOR(state[13], k1);
+}
+
+static void
+HiAE_stream_proc_ad(DATA128b *state, const uint8_t *ad, size_t len)
+{
+    size_t         i      = 0;
+    size_t         rest   = len % UNROLL_BLOCK_SIZE;
+    size_t         prefix = len - rest;
+    const uint8_t *src    = ad;
+    DATA128b       tmp[STATE], M[16];
+    if (len == 0)
+        return;
+    for (; i < prefix; i += UNROLL_BLOCK_SIZE) {
+        AD_UPDATE;
+    }
+    for (; i < len; i += BLOCK_SIZE) {
+        M[0] = SIMD_LOAD(ad + i);
+        UPDATE_STATE_offset(M[0], 0);
+        STATE_SHIFT;
+    }
+    const size_t left = len & BLOCK_SIZE;
+    if (left) {
+        uint8_t padding[BLOCK_SIZE] = { 0 };
+        memcpy(padding, ad + i, left);
+        M[0] = SIMD_LOAD(padding);
+        UPDATE_STATE_offset(M[0], 0);
+        STATE_SHIFT;
+    }
+}
+
+static void
+HiAE_stream_finalize(DATA128b *state, uint64_t ad_len, uint64_t plain_len, uint8_t *tag)
+{
+    uint64_t lens[2];
+    lens[0] = ad_len;
+    lens[1] = plain_len;
+    DATA128b temp, tmp[STATE];
+    temp = SIMD_LOAD((uint8_t *) lens);
+    INIT_UPDATE(temp);
+    INIT_UPDATE(temp);
+    temp = state[0];
+    for (size_t i = 1; i < STATE; ++i) {
+        temp = SIMD_XOR(temp, state[i]);
+    }
+    SIMD_STORE(tag, temp);
+}
+
+int
+crypto_aead_encrypt(unsigned char *c, unsigned long long *clen, const unsigned char *m,
+                    unsigned long long mlen, const unsigned char *ad, unsigned long long adlen,
+                    const unsigned char *nsec, const unsigned char *npub, const unsigned char *k)
+{
+    (void) nsec;
+    (void) m;
+    (void) mlen;
+
+    DATA128b state[STATE];
+    HiAE_stream_init(state, k, npub);
+    HiAE_stream_proc_ad(state, ad, adlen);
+    HiAE_stream_finalize(state, adlen, 0, c);
+
+    *clen = 16;
+
+    return 0;
+}

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -74,10 +74,14 @@ The following MACs are included for benchmarking:
 
 - aegis128: implementation `aesni` from supercop
 - aegis128l: implementation `aesnic` from supercop
-- GCM: implementation `dolbeau/aesenc-int` from supercop, and 
+- aegis128x2: implementation `aesni` from supercop
+- EliMAC: AVX implementation from https://github.com/jedisct1/elimac
+- GCM: implementation `dolbeau/aesenc-int` from supercop
+- HiAE: reference implementation
 - The Jean-Nikolić construction: implementation based on LeMac implementation
 - Rocca: reference code from the ePrint paper: https://eprint.iacr.org/2022/116.pdf
 - Rocca-S: reference code from the draft RFC: https://www.ietf.org/archive/id/draft-nakano-rocca-s-05.html
+- smac1x8: implementation from https://github.com/jedisct1/smac
 - Tiaoxin: implementation `aesnim` from supercop
 
 Original supercop implementations can be obtained by downloading https://bench.cr.yp.to/supercop/supercop-20240909.tar.xz

--- a/benchmark/aegis128x2/Makefile
+++ b/benchmark/aegis128x2/Makefile
@@ -1,0 +1,3 @@
+CFLAGS= -Wall -Wextra -O3 -march=native
+
+bench:

--- a/benchmark/aegis128x2/bench.c
+++ b/benchmark/aegis128x2/bench.c
@@ -1,0 +1,131 @@
+#include <stdint.h>
+#include <stdio.h>
+
+#include "encrypt.c"
+
+// Getrandom
+# if __GLIBC__ > 2 || __GLIBC_MINOR__ > 24
+
+#include <sys/random.h>
+
+#else /* older glibc */
+
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <errno.h>
+
+int getrandom(void *buf, size_t buflen, unsigned int flags) {
+    return syscall(SYS_getrandom, buf, buflen, flags);
+}
+# endif
+
+#ifndef MSIZE
+#define MSIZE 1*1024
+#endif
+
+void setrandom(void* buf, size_t buflen) {
+  size_t l = getrandom(buf, buflen, 0);
+  if (l != buflen) {
+    fprintf(stderr, "Error initializing random state\n");
+    exit(EXIT_FAILURE);
+  }
+}
+
+// Uncomment to use perf_event_open for benchmarks
+// #define PERF_EV
+
+
+// Uncomment to use rdpmc for benchmarks -- this requires running with perf stat -e cycles:u
+// #define USE_RDPMC
+
+
+#ifdef PERF_EV
+// Sample code from perf_event_open manpage
+
+#include <linux/perf_event.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+static long
+perf_event_open(struct perf_event_attr *hw_event, pid_t pid,
+                int cpu, int group_fd, unsigned long flags)
+{
+  int ret;
+
+  ret = syscall(SYS_perf_event_open, hw_event, pid, cpu,
+                group_fd, flags);
+  return ret;
+}
+#endif
+
+int main() {
+  uint8_t *M  = calloc(MSIZE,1);
+  uint8_t  N[16];
+  uint8_t  K[16];
+  uint8_t  T[16];
+
+#ifdef PERF_EV
+  int                     fd;
+  long long               count;
+  struct perf_event_attr  pe;
+
+  memset(&pe, 0, sizeof(pe));
+  pe.type = PERF_TYPE_HARDWARE;
+  pe.size = sizeof(pe);
+  pe.config = PERF_COUNT_HW_CPU_CYCLES;
+  pe.disabled = 1;
+  pe.exclude_kernel = 1;
+  pe.exclude_hv = 1;
+
+  fd = perf_event_open(&pe, 0, -1, -1, 0);
+  if (fd == -1) {
+    fprintf(stderr, "Error opening leader %llx\n", pe.config);
+    exit(EXIT_FAILURE);
+  }
+#endif
+
+  setrandom(M, MSIZE);
+  setrandom(N, sizeof(N));
+  setrandom(K, sizeof(K));
+
+  // Blank computation
+  unsigned long long clen;
+  crypto_aead_encrypt(T, &clen, NULL, 0, M, MSIZE, NULL, N, K);
+
+  // Benchmarks
+  int cycles[1000];
+  for (int i=0; i<1000; i++) {
+#ifdef PERF_EV
+    ioctl(fd, PERF_EVENT_IOC_RESET, 0);
+    ioctl(fd, PERF_EVENT_IOC_ENABLE, 0);
+#else
+#ifdef USE_RDPMC
+    unsigned long long start = __builtin_ia32_rdpmc(0);
+    _mm_lfence();
+#else
+    uint32_t tmp;
+    unsigned long long start = __builtin_ia32_rdtscp (&tmp);
+#endif
+#endif
+    crypto_aead_encrypt(T, &clen, NULL, 0, M, MSIZE, NULL, N, K);
+#ifdef PERF_EV
+    ioctl(fd, PERF_EVENT_IOC_DISABLE, 0);
+    read(fd, &count, sizeof(count));
+    cycles[i] = count;
+#else
+#ifdef USE_RDPMC
+    _mm_lfence();
+    unsigned long long stop = __builtin_ia32_rdpmc(0);
+#else
+    unsigned long long stop = __builtin_ia32_rdtscp (&tmp);
+#endif
+    cycles[i] = stop-start;
+#endif
+  }
+
+  for (int i=0; i<1000; i++) {
+    printf ("%5.3f\n", 1.0*cycles[i]/(MSIZE));
+  }
+}

--- a/benchmark/aegis128x2/encrypt.c
+++ b/benchmark/aegis128x2/encrypt.c
@@ -1,0 +1,303 @@
+#include <limits.h>
+#include <stdint.h>
+#include <string.h>
+
+// common.h
+
+#include <stdint.h>
+#include <string.h>
+
+#if !defined(__cplusplus) && (!defined(__STDC_VERSION__) || __STDC_VERSION__ < 199901L)
+#    ifdef _MSC_VER
+#        define inline __inline
+#    endif
+#endif
+
+#if !defined(__clang__) && !defined(__GNUC__)
+#    ifdef __attribute__
+#        undef __attribute__
+#    endif
+#    define __attribute__(a)
+#endif
+
+#ifndef CRYPTO_ALIGN
+#    if defined(__INTEL_COMPILER) || defined(_MSC_VER)
+#        define CRYPTO_ALIGN(x) __declspec(align(x))
+#    else
+#        define CRYPTO_ALIGN(x) __attribute__((aligned(x)))
+#    endif
+#endif
+
+#define LOAD32_LE(SRC) load32_le(SRC)
+static inline uint32_t
+load32_le(const uint8_t src[4])
+{
+#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    uint32_t w;
+    memcpy(&w, src, sizeof w);
+    return w;
+#else
+    uint32_t w = (uint32_t) src[0];
+    w |= (uint32_t) src[1] << 8;
+    w |= (uint32_t) src[2] << 16;
+    w |= (uint32_t) src[3] << 24;
+    return w;
+#endif
+}
+
+#define STORE32_LE(DST, W) store32_le((DST), (W))
+static inline void
+store32_le(uint8_t dst[4], uint32_t w)
+{
+#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    memcpy(dst, &w, sizeof w);
+#else
+    dst[0] = (uint8_t) w;
+    w >>= 8;
+    dst[1] = (uint8_t) w;
+    w >>= 8;
+    dst[2] = (uint8_t) w;
+    w >>= 8;
+    dst[3] = (uint8_t) w;
+#endif
+}
+
+#define ROTL32(X, B) rotl32((X), (B))
+static inline uint32_t
+rotl32(const uint32_t x, const int b)
+{
+    return (x << b) | (x >> (32 - b));
+}
+
+// encrypt.c
+
+#include <immintrin.h>
+#include <wmmintrin.h>
+
+#ifdef __clang__
+#    pragma clang attribute push(__attribute__((target("aes,avx"))), apply_to = function)
+#elif defined(__GNUC__)
+#    pragma GCC target("aes,avx")
+#endif
+
+#define AES_BLOCK_LENGTH 32
+
+typedef struct {
+    __m128i b0;
+    __m128i b1;
+} aes_block_t;
+
+static inline aes_block_t
+AES_BLOCK_XOR(const aes_block_t a, const aes_block_t b)
+{
+    return (aes_block_t) { _mm_xor_si128(a.b0, b.b0), _mm_xor_si128(a.b1, b.b1) };
+}
+
+static inline aes_block_t
+AES_BLOCK_AND(const aes_block_t a, const aes_block_t b)
+{
+    return (aes_block_t) { _mm_and_si128(a.b0, b.b0), _mm_and_si128(a.b1, b.b1) };
+}
+
+static inline aes_block_t
+AES_BLOCK_LOAD(const uint8_t *a)
+{
+    return (aes_block_t) { _mm_loadu_si128((const __m128i *) (const void *) a),
+                           _mm_loadu_si128((const __m128i *) (const void *) (a + 16)) };
+}
+
+static inline aes_block_t
+AES_BLOCK_LOAD_64x2(uint64_t a, uint64_t b)
+{
+    const __m128i t = _mm_set_epi64x((long long) a, (long long) b);
+    return (aes_block_t) { t, t };
+}
+
+static inline void
+AES_BLOCK_STORE(uint8_t *a, const aes_block_t b)
+{
+    _mm_storeu_si128((__m128i *) (void *) a, b.b0);
+    _mm_storeu_si128((__m128i *) (void *) (a + 16), b.b1);
+}
+
+static inline aes_block_t
+AES_ENC(const aes_block_t a, const aes_block_t b)
+{
+    return (aes_block_t) { _mm_aesenc_si128(a.b0, b.b0), _mm_aesenc_si128(a.b1, b.b1) };
+}
+
+static inline void
+aegis128x2_update(aes_block_t *const state, const aes_block_t d1, const aes_block_t d2)
+{
+    aes_block_t tmp;
+
+    tmp      = state[7];
+    state[7] = AES_ENC(state[6], state[7]);
+    state[6] = AES_ENC(state[5], state[6]);
+    state[5] = AES_ENC(state[4], state[5]);
+    state[4] = AES_ENC(state[3], state[4]);
+    state[3] = AES_ENC(state[2], state[3]);
+    state[2] = AES_ENC(state[1], state[2]);
+    state[1] = AES_ENC(state[0], state[1]);
+    state[0] = AES_ENC(tmp, state[0]);
+
+    state[0] = AES_BLOCK_XOR(state[0], d1);
+    state[4] = AES_BLOCK_XOR(state[4], d2);
+}
+
+// 128x2-common.h
+
+#define RATE 64
+
+static void
+aegis128x2_init(const uint8_t *key, const uint8_t *nonce, aes_block_t *const state)
+{
+    static CRYPTO_ALIGN(AES_BLOCK_LENGTH) const uint8_t c0_[AES_BLOCK_LENGTH] = {
+        0x00, 0x01, 0x01, 0x02, 0x03, 0x05, 0x08, 0x0d, 0x15, 0x22, 0x37,
+        0x59, 0x90, 0xe9, 0x79, 0x62, 0x00, 0x01, 0x01, 0x02, 0x03, 0x05,
+        0x08, 0x0d, 0x15, 0x22, 0x37, 0x59, 0x90, 0xe9, 0x79, 0x62,
+    };
+    static CRYPTO_ALIGN(AES_BLOCK_LENGTH) const uint8_t c1_[AES_BLOCK_LENGTH] = {
+        0xdb, 0x3d, 0x18, 0x55, 0x6d, 0xc2, 0x2f, 0xf1, 0x20, 0x11, 0x31,
+        0x42, 0x73, 0xb5, 0x28, 0xdd, 0xdb, 0x3d, 0x18, 0x55, 0x6d, 0xc2,
+        0x2f, 0xf1, 0x20, 0x11, 0x31, 0x42, 0x73, 0xb5, 0x28, 0xdd,
+    };
+
+    const aes_block_t c0 = AES_BLOCK_LOAD(c0_);
+    const aes_block_t c1 = AES_BLOCK_LOAD(c1_);
+    uint8_t           tmp[2 * 16];
+    uint8_t           context_bytes[AES_BLOCK_LENGTH];
+    aes_block_t       context;
+    aes_block_t       k;
+    aes_block_t       n;
+    int               i;
+
+    memcpy(tmp, key, 16);
+    memcpy(tmp + 16, key, 16);
+    k = AES_BLOCK_LOAD(tmp);
+
+    memcpy(tmp, nonce, 16);
+    memcpy(tmp + 16, nonce, 16);
+    n = AES_BLOCK_LOAD(tmp);
+
+    memset(context_bytes, 0, sizeof context_bytes);
+    context_bytes[0 * 16]     = 0x00;
+    context_bytes[0 * 16 + 1] = 0x01;
+    context_bytes[1 * 16]     = 0x01;
+    context_bytes[1 * 16 + 1] = 0x01;
+    context                   = AES_BLOCK_LOAD(context_bytes);
+
+    state[0] = AES_BLOCK_XOR(k, n);
+    state[1] = c1;
+    state[2] = c0;
+    state[3] = c1;
+    state[4] = AES_BLOCK_XOR(k, n);
+    state[5] = AES_BLOCK_XOR(k, c0);
+    state[6] = AES_BLOCK_XOR(k, c1);
+    state[7] = AES_BLOCK_XOR(k, c0);
+    for (i = 0; i < 10; i++) {
+        state[3] = AES_BLOCK_XOR(state[3], context);
+        state[7] = AES_BLOCK_XOR(state[7], context);
+        aegis128x2_update(state, n, k);
+    }
+}
+
+static void
+aegis128x2_mac(uint8_t *mac, size_t adlen, size_t mlen, aes_block_t *const state)
+{
+    uint8_t     mac_multi_0[AES_BLOCK_LENGTH];
+    uint8_t     mac_multi_1[AES_BLOCK_LENGTH];
+    aes_block_t tmp;
+    int         i;
+
+    tmp = AES_BLOCK_LOAD_64x2(((uint64_t) mlen) << 3, ((uint64_t) adlen) << 3);
+    tmp = AES_BLOCK_XOR(tmp, state[2]);
+
+    for (i = 0; i < 7; i++) {
+        aegis128x2_update(state, tmp, tmp);
+    }
+
+    tmp = AES_BLOCK_XOR(state[6], AES_BLOCK_XOR(state[5], state[4]));
+    tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[3], state[2]));
+    tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[1], state[0]));
+    AES_BLOCK_STORE(mac_multi_0, tmp);
+    for (i = 0; i < 16; i++) {
+        mac[i] = mac_multi_0[i] ^ mac_multi_0[1 * 16 + i];
+    }
+}
+
+static inline void
+aegis128x2_absorb(const uint8_t *const src, aes_block_t *const state)
+{
+    aes_block_t msg0, msg1;
+
+    msg0 = AES_BLOCK_LOAD(src);
+    msg1 = AES_BLOCK_LOAD(src + AES_BLOCK_LENGTH);
+    aegis128x2_update(state, msg0, msg1);
+}
+
+static inline void
+aegis128x2_absorb2(const uint8_t *const src, aes_block_t *const state)
+{
+    aes_block_t msg0, msg1, msg2, msg3;
+
+    msg0 = AES_BLOCK_LOAD(src + 0 * AES_BLOCK_LENGTH);
+    msg1 = AES_BLOCK_LOAD(src + 1 * AES_BLOCK_LENGTH);
+    msg2 = AES_BLOCK_LOAD(src + 2 * AES_BLOCK_LENGTH);
+    msg3 = AES_BLOCK_LOAD(src + 3 * AES_BLOCK_LENGTH);
+    aegis128x2_update(state, msg0, msg1);
+    aegis128x2_update(state, msg2, msg3);
+}
+
+static int
+encrypt_detached(uint8_t *c, uint8_t *mac, size_t maclen, const uint8_t *m, size_t mlen,
+                 const uint8_t *ad, size_t adlen, const uint8_t *npub, const uint8_t *k)
+{
+    aes_block_t                state[8];
+    CRYPTO_ALIGN(RATE) uint8_t src[RATE];
+    size_t                     i;
+
+    (void) c;
+    (void) m;
+    (void) mlen;
+
+    aegis128x2_init(k, npub, state);
+
+    for (i = 0; i + RATE * 2 <= adlen; i += RATE * 2) {
+        aegis128x2_absorb2(ad + i, state);
+    }
+    for (; i + RATE <= adlen; i += RATE) {
+        aegis128x2_absorb(ad + i, state);
+    }
+    if (adlen % RATE) {
+        memset(src, 0, RATE);
+        memcpy(src, ad + i, adlen % RATE);
+        aegis128x2_absorb(src, state);
+    }
+    aegis128x2_mac(mac, adlen, mlen, state);
+
+    return 0;
+}
+
+int
+crypto_aead_encrypt(unsigned char *c, unsigned long long *clen, const unsigned char *m,
+                    unsigned long long mlen, const unsigned char *ad, unsigned long long adlen,
+                    const unsigned char *nsec, const unsigned char *npub, const unsigned char *k)
+{
+    (void) nsec;
+    (void) m;
+    (void) mlen;
+
+    if (encrypt_detached(NULL, c, 16, NULL, 0U,
+                         (const uint8_t *) ad, (size_t) adlen,
+                         (const uint8_t *) npub, (const uint8_t *) k) != 0) {
+        return -1;
+    }
+    *clen = 16;
+
+    return 0;
+}
+
+#ifdef __clang__
+#    pragma clang attribute pop
+#endif

--- a/benchmark/smac1x8/Makefile
+++ b/benchmark/smac1x8/Makefile
@@ -1,0 +1,3 @@
+CFLAGS= -Wall -Wextra -O3 -march=native
+
+bench:

--- a/benchmark/smac1x8/bench.c
+++ b/benchmark/smac1x8/bench.c
@@ -1,0 +1,131 @@
+#include <stdint.h>
+#include <stdio.h>
+
+#include "mac.c"
+
+// Getrandom
+# if __GLIBC__ > 2 || __GLIBC_MINOR__ > 24
+
+#include <sys/random.h>
+
+#else /* older glibc */
+
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <errno.h>
+
+int getrandom(void *buf, size_t buflen, unsigned int flags) {
+    return syscall(SYS_getrandom, buf, buflen, flags);
+}
+# endif
+
+#ifndef MSIZE
+#define MSIZE 1*1024
+#endif
+
+void setrandom(void* buf, size_t buflen) {
+  size_t l = getrandom(buf, buflen, 0);
+  if (l != buflen) {
+    fprintf(stderr, "Error initializing random state\n");
+    exit(EXIT_FAILURE);
+  }
+}
+
+// Uncomment to use perf_event_open for benchmarks
+// #define PERF_EV
+
+
+// Uncomment to use rdpmc for benchmarks -- this requires running with perf stat -e cycles:u
+// #define USE_RDPMC
+
+
+#ifdef PERF_EV
+// Sample code from perf_event_open manpage
+
+#include <linux/perf_event.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+static long
+perf_event_open(struct perf_event_attr *hw_event, pid_t pid,
+                int cpu, int group_fd, unsigned long flags)
+{
+  int ret;
+
+  ret = syscall(SYS_perf_event_open, hw_event, pid, cpu,
+                group_fd, flags);
+  return ret;
+}
+#endif
+
+int main() {
+  uint8_t *M  = calloc(MSIZE,1);
+  uint8_t  K[32];
+  uint8_t  N[15];
+  uint8_t  T[32];
+
+#ifdef PERF_EV
+  int                     fd;
+  long long               count;
+  struct perf_event_attr  pe;
+
+  memset(&pe, 0, sizeof(pe));
+  pe.type = PERF_TYPE_HARDWARE;
+  pe.size = sizeof(pe);
+  pe.config = PERF_COUNT_HW_CPU_CYCLES;
+  pe.disabled = 1;
+  pe.exclude_kernel = 1;
+  pe.exclude_hv = 1;
+
+  fd = perf_event_open(&pe, 0, -1, -1, 0);
+  if (fd == -1) {
+    fprintf(stderr, "Error opening leader %llx\n", pe.config);
+    exit(EXIT_FAILURE);
+  }
+#endif
+
+  setrandom(M, MSIZE);
+  setrandom(N, sizeof(N));
+  setrandom(K, sizeof(K));
+
+  // Blank computation
+  smac(T, M, MSIZE, NULL, 0, K, N);
+
+  // Benchmarks
+  int cycles[1000];
+  for (int i=0; i<1000; i++) {
+#ifdef PERF_EV
+    ioctl(fd, PERF_EVENT_IOC_RESET, 0);
+    ioctl(fd, PERF_EVENT_IOC_ENABLE, 0);
+#else
+#ifdef USE_RDPMC
+    unsigned long long start = __builtin_ia32_rdpmc(0);
+    _mm_lfence();
+#else
+    uint32_t tmp;
+    unsigned long long start = __builtin_ia32_rdtscp (&tmp);
+#endif
+#endif
+    smac(T, M, MSIZE, NULL, 0, K, N);
+    __asm__ __volatile__ ("" : : "r"(T) : "memory");
+#ifdef PERF_EV
+    ioctl(fd, PERF_EVENT_IOC_DISABLE, 0);
+    read(fd, &count, sizeof(count));
+    cycles[i] = count;
+#else
+#ifdef USE_RDPMC
+    _mm_lfence();
+    unsigned long long stop = __builtin_ia32_rdpmc(0);
+#else
+    unsigned long long stop = __builtin_ia32_rdtscp (&tmp);
+#endif
+    cycles[i] = stop-start;
+#endif
+  }
+
+  for (int i=0; i<1000; i++) {
+    printf ("%5.3f\n", 1.0*cycles[i]/(MSIZE));
+  }
+}

--- a/benchmark/smac1x8/mac.c
+++ b/benchmark/smac1x8/mac.c
@@ -1,0 +1,201 @@
+#define smac_MACBYTES   32
+#define smac_KEYBYTES   32
+#define smac_NONCEBYTES 15
+#define smac_BLOCKBYTES (16 * 8)
+
+#include <stddef.h>
+#include <string.h>
+
+#include <immintrin.h>
+#include <wmmintrin.h>
+
+typedef struct {
+    __m128i b0;
+    __m128i b1;
+    __m128i b2;
+    __m128i b3;
+    __m128i b4;
+    __m128i b5;
+    __m128i b6;
+    __m128i b7;
+} aes_block_t;
+
+static inline __m128i
+AES_BLOCK_XOR1(const __m128i a, const __m128i b)
+{
+    return _mm_xor_si128(a, b);
+}
+
+static inline aes_block_t
+AES_BLOCK_XOR(const aes_block_t a, const aes_block_t b)
+{
+    return (aes_block_t) {
+        _mm_xor_si128(a.b0, b.b0), _mm_xor_si128(a.b1, b.b1), _mm_xor_si128(a.b2, b.b2),
+        _mm_xor_si128(a.b3, b.b3), _mm_xor_si128(a.b4, b.b4), _mm_xor_si128(a.b5, b.b5),
+        _mm_xor_si128(a.b6, b.b6), _mm_xor_si128(a.b7, b.b7),
+    };
+}
+
+static inline aes_block_t
+AES_BLOCK_LOAD(const uint8_t *a)
+{
+    return (aes_block_t) {
+        _mm_loadu_si128((const __m128i *) (const void *) a),
+        _mm_loadu_si128((const __m128i *) (const void *) (a + 16)),
+        _mm_loadu_si128((const __m128i *) (const void *) (a + 32)),
+        _mm_loadu_si128((const __m128i *) (const void *) (a + 48)),
+        _mm_loadu_si128((const __m128i *) (const void *) (a + 64)),
+        _mm_loadu_si128((const __m128i *) (const void *) (a + 80)),
+        _mm_loadu_si128((const __m128i *) (const void *) (a + 96)),
+        _mm_loadu_si128((const __m128i *) (const void *) (a + 112)),
+    };
+}
+
+static inline aes_block_t
+AES_BLOCK_LOAD_BROADCAST(const uint8_t *a)
+{
+    const __m128i x = _mm_loadu_si128((const __m128i *) (const void *) a);
+    return (aes_block_t) { x, x, x, x, x, x, x, x };
+}
+
+static inline aes_block_t
+AES_BLOCK_LOAD_64x2(uint64_t a, uint64_t b)
+{
+    const __m128i t = _mm_set_epi64x((long long) a, (long long) b);
+    return (aes_block_t) { t, t, t, t, t, t, t, t };
+}
+
+static inline void
+AES_BLOCK_STORE(uint8_t *a, const aes_block_t b)
+{
+    _mm_storeu_si128((__m128i *) (void *) a, b.b0);
+    _mm_storeu_si128((__m128i *) (void *) (a + 16), b.b1);
+    _mm_storeu_si128((__m128i *) (void *) (a + 32), b.b2);
+    _mm_storeu_si128((__m128i *) (void *) (a + 48), b.b3);
+    _mm_storeu_si128((__m128i *) (void *) (a + 64), b.b4);
+    _mm_storeu_si128((__m128i *) (void *) (a + 80), b.b5);
+    _mm_storeu_si128((__m128i *) (void *) (a + 96), b.b6);
+    _mm_storeu_si128((__m128i *) (void *) (a + 112), b.b7);
+}
+
+static inline void
+AES_BLOCK_STORE1(uint8_t *a, const aes_block_t b)
+{
+    _mm_storeu_si128((__m128i *) (void *) a, b.b0);
+}
+
+static inline aes_block_t
+AES_ENC(const aes_block_t a, const aes_block_t b)
+{
+    return (aes_block_t) {
+        _mm_aesenc_si128(a.b0, b.b0), _mm_aesenc_si128(a.b1, b.b1), _mm_aesenc_si128(a.b2, b.b2),
+        _mm_aesenc_si128(a.b3, b.b3), _mm_aesenc_si128(a.b4, b.b4), _mm_aesenc_si128(a.b5, b.b5),
+        _mm_aesenc_si128(a.b6, b.b6), _mm_aesenc_si128(a.b7, b.b7),
+    };
+}
+
+#define P(A) \
+    _mm_shuffle_epi8(A, _mm_setr_epi8(0, 7, 14, 11, 4, 13, 10, 1, 8, 15, 6, 3, 12, 5, 2, 9))
+
+#define PERMUTE(a)                                                             \
+    (aes_block_t)                                                              \
+    {                                                                          \
+        P(a.b0), P(a.b1), P(a.b2), P(a.b3), P(a.b4), P(a.b5), P(a.b6), P(a.b7) \
+    }
+
+#define COMPRESS(state, m)                                                                         \
+    do {                                                                                           \
+        state = (smac_state) { .a1 = PERMUTE(AES_BLOCK_XOR(AES_BLOCK_XOR(state.a2, state.a3), m)), \
+                               .a2 = AES_ENC(state.a1, m),                                         \
+                               .a3 = AES_ENC(state.a2, m) };                                       \
+    } while (0)
+
+typedef struct smac_state {
+    aes_block_t a1, a2, a3;
+} smac_state;
+
+void
+smac(uint8_t tag[smac_MACBYTES], const uint8_t *ad, const size_t ad_len, const uint8_t *ct,
+     const size_t ct_len, const uint8_t key[smac_KEYBYTES], const uint8_t nonce[smac_NONCEBYTES])
+{
+    smac_state  state, s0;
+    uint8_t     nonce_patched[smac_BLOCKBYTES];
+    uint8_t     pad[smac_BLOCKBYTES];
+    aes_block_t m;
+    size_t      i, left;
+
+    for (i = 0; i < sizeof nonce_patched / (smac_NONCEBYTES + 1); i++) {
+        memcpy(nonce_patched + i * (smac_NONCEBYTES + 1), nonce, smac_NONCEBYTES);
+        nonce_patched[i * (smac_NONCEBYTES + 1) + smac_NONCEBYTES] = i | (4 << 4);
+    }
+    state = (smac_state) { .a1 = AES_BLOCK_LOAD_BROADCAST(key),
+                           .a2 = AES_BLOCK_LOAD_BROADCAST(key + 16),
+                           .a3 = AES_BLOCK_LOAD_BROADCAST(nonce_patched) };
+    s0    = state;
+    m     = AES_BLOCK_LOAD_64x2(0, 1);
+    for (i = 0; i < 9; i++) {
+        COMPRESS(state, m);
+    }
+    state = (smac_state) { .a1 = AES_BLOCK_XOR(state.a1, s0.a1),
+                           .a2 = AES_BLOCK_XOR(state.a2, s0.a2),
+                           .a3 = AES_BLOCK_XOR(state.a3, s0.a3) };
+
+    for (i = 0; i + smac_BLOCKBYTES * 2 <= ad_len; i += smac_BLOCKBYTES * 2) {
+        m = AES_BLOCK_LOAD(ad + i);
+        COMPRESS(state, m);
+        m = AES_BLOCK_LOAD(ad + i + smac_BLOCKBYTES);
+        COMPRESS(state, m);
+    }
+    for (; i + smac_BLOCKBYTES <= ad_len; i += smac_BLOCKBYTES) {
+        m = AES_BLOCK_LOAD(ad + i);
+        COMPRESS(state, m);
+    }
+    left = ad_len % smac_BLOCKBYTES;
+    if (left != 0) {
+        memset(pad, 0, sizeof pad);
+        memcpy(pad, ad, left);
+        m = AES_BLOCK_LOAD(pad);
+        COMPRESS(state, m);
+    }
+
+    for (i = 0; i + smac_BLOCKBYTES * 2 <= ct_len; i += smac_BLOCKBYTES * 2) {
+        m = AES_BLOCK_LOAD(ct + i);
+        COMPRESS(state, m);
+        m = AES_BLOCK_LOAD(ct + i + smac_BLOCKBYTES);
+        COMPRESS(state, m);
+    }
+    for (; i + smac_BLOCKBYTES <= ct_len; i += smac_BLOCKBYTES) {
+        m = AES_BLOCK_LOAD(ct + i);
+        COMPRESS(state, m);
+    }
+    left = ct_len % smac_BLOCKBYTES;
+    if (left != 0) {
+        memset(pad, 0, sizeof pad);
+        memcpy(pad, ct, left);
+        m = AES_BLOCK_LOAD(pad);
+        COMPRESS(state, m);
+    }
+
+    m = AES_BLOCK_LOAD_64x2(ct_len * 8, ad_len * 8);
+    COMPRESS(state, m);
+
+    state.a1.b0 = AES_BLOCK_XOR1(state.a1.b0, state.a1.b1);
+    state.a1.b0 = AES_BLOCK_XOR1(state.a1.b0, state.a1.b2);
+    state.a1.b0 = AES_BLOCK_XOR1(state.a1.b0, state.a1.b3);
+    state.a1.b0 = AES_BLOCK_XOR1(state.a1.b0, state.a1.b4);
+    state.a1.b0 = AES_BLOCK_XOR1(state.a1.b0, state.a1.b5);
+    state.a1.b0 = AES_BLOCK_XOR1(state.a1.b0, state.a1.b6);
+    state.a1.b0 = AES_BLOCK_XOR1(state.a1.b0, state.a1.b7);
+
+    s0 = state;
+    m  = AES_BLOCK_LOAD_64x2(0, 1);
+    for (i = 0; i < 9; i++) {
+        COMPRESS(state, m);
+    }
+    state = (smac_state) { .a1 = AES_BLOCK_XOR(state.a1, s0.a1),
+                           .a2 = AES_BLOCK_XOR(state.a2, s0.a2),
+                           .a3 = AES_BLOCK_XOR(state.a3, s0.a3) };
+
+    AES_BLOCK_STORE1(tag, state.a2);
+    AES_BLOCK_STORE1(tag + 16, state.a3);
+}


### PR DESCRIPTION
Even though AVX2 and AVX512 implementations are available, import only implementations that don't use VAES.